### PR TITLE
Conda load

### DIFF
--- a/buildstockbatch/eagle.sh
+++ b/buildstockbatch/eagle.sh
@@ -5,10 +5,7 @@
 echo "Job ID: $SLURM_JOB_ID"
 echo "Hostname: $HOSTNAME"
 
-CONDA_DIR=/shared-projects/buildstock/
-NAME=buildstock
-
 module load conda singularity-container
-source activate $CONDA_DIR/$NAME
+source activate buildstock
 
 time python -u -m buildstockbatch.eagle "$PROJECTFILE"

--- a/create_eagle_env.sh
+++ b/create_eagle_env.sh
@@ -5,14 +5,9 @@
 #SBATCH --nodes=1
 #SBATCH --time=15:00
 
-CONDA_DIR=/shared-projects/buildstock/
-NAME=buildstock
-
 module load conda
-if [[ ! -d $CONDA_DIR/$NAME ]]; then
-    conda remove -y --prefix $CONDA_DIR/$NAME --all
-    conda create -y --prefix $CONDA_DIR/$NAME python=3.6 pandas hdf5 pytables
-fi
-source activate $CONDA_DIR/$NAME
+conda remove -y --name buildstock --all
+conda create -y --name buildstock python=3.6 pandas hdf5 pytables
+source activate buildstock
 pip install --upgrade pip
 pip install -e .


### PR DESCRIPTION
So our jobs were impacting the Eagle /home filesystem.  It seemed that loading the conda environment stored in /home/$USER was slowing down the entire file system.  I created a new environment in /shared-projects/buildstock so that anyone can use this environment.  

Also in this branch, I fixed a bug in the post-processing the results.csv when a job failed and produces no data in the <project_folder>/results/bldg* folder.