### PR TITLE
Update due to changes in the TimeseriesCSVExport measure

### DIFF
--- a/buildstockbatch/workflow_generator/residential.py
+++ b/buildstockbatch/workflow_generator/residential.py
@@ -115,8 +115,6 @@ class ResidentialDefaultWorkflowGenerator(WorkflowGeneratorBase):
                 'measure_dir_name': 'TimeseriesCSVExport',
                 'arguments': deepcopy(self.cfg['timeseries_csv_export'])
             }
-            timeseries_measure['arguments']['output_variables'] = \
-                ','.join(self.cfg['timeseries_csv_export']['output_variables'])
             osw['steps'].insert(-1, timeseries_measure)
 
         return osw

--- a/project_resstock_multifamily.yml
+++ b/project_resstock_multifamily.yml
@@ -11,10 +11,6 @@ timeseries_csv_export:
   reporting_frequency: Hourly
   inc_end_use_subcategories: true
   inc_output_variables: true
-  output_variables:
-    - Zone Mean Air Temperature
-    - Zone Mean Air Humidity Ratio
-    - Fan Runtime Fraction
 output_directory: /scratch/nmerket/multifamily10k
 peregrine:
   minutes_per_sim: 60

--- a/project_resstock_national.yml
+++ b/project_resstock_national.yml
@@ -20,10 +20,6 @@ upgrades:
 timeseries_csv_export:
   reporting_frequency: Hourly
   include_enduse_subcategories: true
-  output_variables:
-    - Zone Mean Air Temperature
-    - Zone Mean Air Humidity Ratio
-    - Fan Runtime Fraction
 # downselect:
 #   resample: false
 #   logic:

--- a/project_resstock_national_upgrades.yml
+++ b/project_resstock_national_upgrades.yml
@@ -484,10 +484,6 @@ timeseries_csv_export:
   reporting_frequency: Hourly
   inc_end_use_subcategories: true
   inc_output_variables: true
-  output_variables:
-    - Zone Mean Air Temperature
-    - Zone Mean Air Humidity Ratio
-    - Fan Runtime Fraction
 downselect:
   resample: false
   logic:


### PR DESCRIPTION
Updating residential workflow generator as the arguments in the TimeseriesCSVExport measures have changed.  The output_variables argument no longer exists.  In the project YAML files, the output_variables inputs have also been removed.