### PR TITLE
Eagle create environment shell script catches if no environment name provided

### DIFF
--- a/create_eagle_env.sh
+++ b/create_eagle_env.sh
@@ -26,7 +26,7 @@ MY_CONDA_PREFIX="$CONDA_ENVS_DIR/$MY_CONDA_ENV_NAME"
 echo "Creating $MY_CONDA_PREFIX"
 module load conda
 conda remove -y --prefix "$MY_CONDA_PREFIX" --all
-conda create -y --prefix "$MY_CONDA_PREFIX" python=3.7 pandas hdf5
+conda create -y --prefix "$MY_CONDA_PREFIX" -c conda-forge "pyarrow>=0.14" python=3.7 pandas dask distributed
 source activate "$MY_CONDA_PREFIX"
 pip install --upgrade pip
 if [ $DEV -eq 1 ]


### PR DESCRIPTION
Fixes # 58.

## Pull Request Description

As described in #58, previously if you ran the `create_eagle_env.sh` script, it would overwrite everyone's environments if you didn't provide an environment name. This catches that and errors out before anything catastrophic happens.

## Checklist

Not all may apply

- [ ] Code changes (must work)
- [x] ~~Tests exercising your feature/bug fix~~ not part of test suite
- [ ] All other unit tests passing
- [x] ~~Update validation for project config yaml file changes~~ n/a
- [x] ~~Update documentation~~ n/a
- [ ] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
