### PR TITLE
Make workflow generator compatible with older resstock.

### DIFF
--- a/buildstockbatch/workflow_generator/residential.py
+++ b/buildstockbatch/workflow_generator/residential.py
@@ -72,9 +72,7 @@ class ResidentialDefaultWorkflowGenerator(WorkflowGeneratorBase):
 
         osw['steps'].extend(self.cfg['baseline'].get('measures', []))
 
-        sim_output_args = {
-            'include_enduse_subcategories': False
-        }
+        sim_output_args = {}
         sim_output_args.update(self.cfg.get('simulation_output', {}))
 
         osw['steps'].extend([


### PR DESCRIPTION
## Pull Request Description

This fixes a backward compatibility issue between a OpenStudio-BuildStock reporting measure (<= v2.1.0) and the buildstockbatch workflow generator. Basically if you had no `simulation_output` in your yml file, then the workflow generator would assign an argument to the reporting measure that doesn't exist. It would pass validation but then hit an error in the simulation.

## Checklist

Not all may apply

- [ ] Code changes (must work)
- [ ] Tests exercising your feature/bug fix (check coverage report on CircleCI build -> Artifacts)
- [x] All other unit tests passing
- [x] Update validation for project config yaml file changes
- [x] Update documentation
- [x] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
