### PR TITLE
add .python-version to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ venv/*
 *.zip
 .pytest_cache
 *.pyc
+.python-version


### PR DESCRIPTION
## Pull Request Description

.python-version is the file created by [pyenv](https://github.com/pyenv/pyenv) to set which python version or virtual env is enabled for this directory. Each developer that uses pyenv (and especially using [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv)) will have their own version of this file in their local repo.

## Checklist

- [x] All other unit tests passing
