### PR TITLE
Closes #135, fix newline characters in results csv

### DIFF
--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -297,7 +297,7 @@ def combine_results(fs, results_dir, cfg, do_timeseries=True):
         logger.info(f'Writing {csv_filename}')
         with fs.open(csv_filename, 'wb') as f:
             with gzip.open(f, 'wt', encoding='utf-8') as gf:
-                df.to_csv(gf, index=True)
+                df.to_csv(gf, index=True, line_terminator='\n')
 
         # Write Parquet
         if upgrade_id == 0:


### PR DESCRIPTION
Fixes #135.

## Pull Request Description

Docker on windows was producing LFCRLF (instead of just CRLF) in results csvs.

## Checklist

Not all may apply

- [ ] Code changes (must work)
- [ ] Tests exercising your feature/bug fix (check coverage report on CircleCI build -> Artifacts)
- [ ] All other unit tests passing
- [ ] Update validation for project config yaml file changes
- [ ] Update documentation
- [ ] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
