### PR TITLE
Pinning pandas version for aws postprocessing

### DIFF
--- a/buildstockbatch/aws/s3_assets/bootstrap-dask-custom
+++ b/buildstockbatch/aws/s3_assets/bootstrap-dask-custom
@@ -40,9 +40,8 @@ conda install \
 -q \
 python=3.7 \
 "dask-yarn>=0.7.0" \
-pandas \
+"pandas>=1.0.0,!=1.0.4" \
 "pyarrow>=0.14.1" \
-pandas \
 s3fs \
 conda-pack \
 tornado=5 

--- a/buildstockbatch/aws/s3_assets/setup_postprocessing.py
+++ b/buildstockbatch/aws/s3_assets/setup_postprocessing.py
@@ -9,7 +9,7 @@ setup(
         'dask[complete]',
         's3fs>=0.4.0',
         'boto3',
-        'pandas',
+        'pandas>=1.0.0,!=1.0.4',
         'pyarrow>=0.14.1',
     ]
 )


### PR DESCRIPTION
## Pull Request Description

[Pandas 1.0.4 is broken](https://github.com/pandas-dev/pandas/issues/34467). I fixed it for Eagle in #161. I fixed it in the setup.py in #160. This adds that fix to the dask bootstrap script as well so it works on AWS.
 
## Checklist

Not all may apply

- [x] Code changes (must work)
- [x] Tests exercising your feature/bug fix (check coverage report on CircleCI build -> Artifacts)
- [x] All other unit tests passing
- [x] Update validation for project config yaml file changes
- [x] Update existing documentation
- [x] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
- [x] Add to the changelog_dev.rst file and propose migration text in the pull request
