### PR TITLE
Enable Commercial Local Docker Runs

### DIFF
--- a/buildstockbatch/localdocker.py
+++ b/buildstockbatch/localdocker.py
@@ -229,9 +229,9 @@ class LocalDockerBatch(DockerBatchBase):
         ]
         if cfg.get('baseline', dict()).get('custom_gems', False):
             args.insert(1, '--bundle')
-            args.insert(2, 'mnt_gemfile_path')
+            args.insert(2, '/var/simdata/openstudio/.custom_gems/Gemfile')
             args.insert(3, '--bundle_path')
-            args.insert(4, 'mnt_custom_gem_dir')
+            args.insert(4, '/var/simdata/openstudio/.custom_gems/')
             args.append('--debug')
         if measures_only:
             args.insert(2, '--measures_only')

--- a/buildstockbatch/localdocker.py
+++ b/buildstockbatch/localdocker.py
@@ -95,29 +95,27 @@ class DockerBatchBase(BuildStockBatchBase):
 
             docker_client = docker.client.from_env()
 
-            # Install custom gems to be used in the docker container
+            # Define the paths for the Gemfile and openstudio-gems.gemspec files
             local_gemfile_path = os.path.join('/mnt/dc-comstock/repos/comstock', 'resources', 'Gemfile')
             mnt_gemfile_path = f"{mnt_custom_gem_dir}/Gemfile"
+            local_gemspec_path = os.path.join('/mnt/dc-comstock/repos/comstock', 'resources', 'openstudio-gems.gemspec')
+            mnt_gemspec_path = f"{mnt_custom_gem_dir}/openstudio-gems.gemspec"
 
-            # Check that the Gemfile exists
+            # Check that the Gemfile and openstudio-gems.gemspec exists
             if not os.path.exists(local_gemfile_path):
                 print(f'local_gemfile_path = {local_gemfile_path}')
                 raise AttributeError(
                     'baseline:custom_gems = True, but did not find Gemfile in /resources directory')
-            
-            # Install custom gemspec to be used in the docker container
-            local_gemspec_path = os.path.join('/mnt/dc-comstock/repos/comstock', 'resources', 'openstudio-gems.gemspec')
-            mnt_gemspec_path = f"{mnt_custom_gem_dir}/openstudio-gems.gemspec"
-
-            # Check that the .gemspec file exists
             if not os.path.exists(local_gemspec_path):
                 print(f'local_gemspec_path = {local_gemspec_path}')
                 raise AttributeError(
                     'baseline:custom_gems = True, but did not find openstudio-gems.gemspec in /resources directory')
 
-            # Make the .custom_gems dir if it doesn't already exist and copy in Gemfile from /resources
+            # Make the .custom_gems dir if it doesn't already exist and copy in Gemfile & openstudio-gems.gemspec from /resources
             if not os.path.exists(os.path.join('/mnt/dc-comstock/repos/comstock', '.custom_gems', 'openstudio-gems.gemspec')):
-                shutil.copyfile(local_gemspec_path, os.path.join('/mnt/dc-comstock/repos/comstock', '.custom_gems', 'openstudio-gems.gemspec'))
+                os.makedirs('/mnt/dc-comstock/repos/comstock/.custom_gems')
+            shutil.copyfile(local_gemfile_path, os.path.join('/mnt/dc-comstock/repos/comstock', '.custom_gems', 'Gemfile'))
+            shutil.copyfile(local_gemspec_path, os.path.join('/mnt/dc-comstock/repos/comstock', '.custom_gems', 'openstudio-gems.gemspec'))
 
             # Install the custom gems
             bundle_install_args = [

--- a/buildstockbatch/localdocker.py
+++ b/buildstockbatch/localdocker.py
@@ -151,13 +151,20 @@ class LocalDockerBatch(DockerBatchBase):
         args = [
             'openstudio',
             'run',
-            '-w', 'in.osw',
+            '-w', 'in.osw'
         ]
+        if cfg.get('baseline', dict()).get('custom_gems', False):
+            args.insert(2, '--bundle')
+            args.insert(3, '/var/oscli/Gemfile')
+            args.insert(4, '--bundle_path')
+            args.insert(5, '/var/oscli/gems')
+            args.insert(6, '--debug')
         if measures_only:
             args.insert(2, '--measures_only')
         extra_kws = {}
         if sys.platform.startswith('linux'):
             extra_kws['user'] = f'{os.getuid()}:{os.getgid()}'
+            extra_kws['stderr'] = True
         container_output = docker_client.containers.run(
             docker_image,
             args,

--- a/buildstockbatch/localdocker.py
+++ b/buildstockbatch/localdocker.py
@@ -86,7 +86,7 @@ class DockerBatchBase(BuildStockBatchBase):
             logger.info('Installing custom gems')
 
             # Define directories to be mounted in the container
-            local_custom_gem_dir = os.path.join('/mnt/dc-comstock/repos/comstock', '.custom_gems')
+            local_custom_gem_dir = os.path.join(self.buildstock_dir, '.custom_gems')
             mnt_custom_gem_dir = '/var/simdata/openstudio/.custom_gems'
             bind_mounts = [
                 (local_custom_gem_dir, mnt_custom_gem_dir, 'rw')
@@ -96,10 +96,10 @@ class DockerBatchBase(BuildStockBatchBase):
             docker_client = docker.client.from_env()
 
             # Define the paths for the Gemfile and openstudio-gems.gemspec files
-            local_gemfile_path = os.path.join('/mnt/dc-comstock/repos/comstock', 'resources', 'Gemfile')
+            local_gemfile_path = os.path.join(self.buildstock_dir, 'resources', 'Gemfile')
             mnt_gemfile_path = f"{mnt_custom_gem_dir}/Gemfile"
-            local_gemspec_path = os.path.join('/mnt/dc-comstock/repos/comstock', 'resources', 'openstudio-gems.gemspec')
-            mnt_gemspec_path = f"{mnt_custom_gem_dir}/openstudio-gems.gemspec"
+            local_gemspec_path = os.path.join(self.buildstock_dir, 'resources', 'openstudio-gems.gemspec')
+            # mnt_gemspec_path = f"{mnt_custom_gem_dir}/openstudio-gems.gemspec"
 
             # Check that the Gemfile and openstudio-gems.gemspec exists
             if not os.path.exists(local_gemfile_path):
@@ -112,10 +112,10 @@ class DockerBatchBase(BuildStockBatchBase):
                     'baseline:custom_gems = True, but did not find openstudio-gems.gemspec in /resources directory')
 
             # Make the .custom_gems dir if it doesn't already exist and copy in Gemfile & openstudio-gems.gemspec from /resources
-            if not os.path.exists(os.path.join('/mnt/dc-comstock/repos/comstock', '.custom_gems', 'openstudio-gems.gemspec')):
-                os.makedirs('/mnt/dc-comstock/repos/comstock/.custom_gems')
-            shutil.copyfile(local_gemfile_path, os.path.join('/mnt/dc-comstock/repos/comstock', '.custom_gems', 'Gemfile'))
-            shutil.copyfile(local_gemspec_path, os.path.join('/mnt/dc-comstock/repos/comstock', '.custom_gems', 'openstudio-gems.gemspec'))
+            if not os.path.exists(os.path.join(self.buildstock_dir, '.custom_gems', 'openstudio-gems.gemspec')):
+                os.makedirs(os.path.join(self.buildstock_dir, '.custom_gems'))
+            shutil.copyfile(local_gemfile_path, os.path.join(self.buildstock_dir, '.custom_gems', 'Gemfile'))
+            shutil.copyfile(local_gemspec_path, os.path.join(self.buildstock_dir, '.custom_gems', 'openstudio-gems.gemspec'))
 
             # Install the custom gems
             bundle_install_args = [
@@ -206,7 +206,7 @@ class LocalDockerBatch(DockerBatchBase):
             (sim_dir, '', 'rw'),
             (os.path.join(buildstock_dir, 'measures'), 'measures', 'ro'),
             (os.path.join(buildstock_dir, 'resources'), 'lib/resources', 'ro'),
-            (os.path.join(buildstock_dir, '.custom_gems'), '/mnt/dc-comstock/repos/comstock', 'rw'),
+            (os.path.join(buildstock_dir, '.custom_gems'), '.custom_gems', 'rw'),
             (os.path.join(project_dir, 'housing_characteristics'), 'lib/housing_characteristics', 'ro'),
             (weather_dir, 'weather', 'ro')
         ]

--- a/buildstockbatch/localdocker.py
+++ b/buildstockbatch/localdocker.py
@@ -239,7 +239,6 @@ class LocalDockerBatch(DockerBatchBase):
         if sys.platform.startswith('linux'):
             extra_kws['user'] = f'{os.getuid()}:{os.getgid()}'
             extra_kws['stderr'] = True
-        breakpoint()
         container_output = docker_client.containers.run(
             docker_image,
             args,

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setuptools.setup(
         'pandas>=1.0.0,!=1.0.4',
         'joblib',
         'pyarrow>=0.14.1',
-        'dask[complete]>=2.1.0',
+        'dask[complete]>=2.17.2',
         'docker',
         'boto3>=1.10.44',
         's3fs>=0.4.0',


### PR DESCRIPTION
Allows for use of custom gems (basically the openstudio-standards gem) in local docker runs - this is a required feature for allowing commercial usage of the local-docker infrastructure set.

## Pull Request Description

In this PR the `custom_gems` key in the configuration yaml in local docker infrastructure runs will trigger a build of all gems required by the OpenStudio CLI, including the specified custom gems. They are persisted to the local machine and subsequently bind-mounted as ro in each subsequent simulation. 

## Checklist

Work remains to be done on this.

Not all may apply

- [X] Code changes (must work)
- [ ] Tests exercising your feature/bug fix (check coverage report on CircleCI build -> Artifacts)
- [ ] All other unit tests passing
- [X] Update validation for project config yaml file changes
- [ ] Update existing documentation
- [X] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
- [ ] Add to the changelog_dev.rst file and propose migration text in the pull request
