### PR TITLE
Pinning s3fs version for AWS postprocessing

### DIFF
--- a/buildstockbatch/aws/s3_assets/bootstrap-dask-custom
+++ b/buildstockbatch/aws/s3_assets/bootstrap-dask-custom
@@ -42,7 +42,7 @@ python=3.7 \
 "dask-yarn>=0.7.0" \
 "pandas>=1.0.0,!=1.0.4" \
 "pyarrow>=0.14.1" \
-s3fs \
+"s3fs>=0.4.2,<0.5.0" \
 conda-pack \
 tornado=5 
 

--- a/buildstockbatch/aws/s3_assets/setup_postprocessing.py
+++ b/buildstockbatch/aws/s3_assets/setup_postprocessing.py
@@ -3,11 +3,11 @@ from setuptools import setup
 setup(
     name='buildstockbatch-postprocessing',
     version='0.1',
-    description='Just the stand along postprocessing functions from Buildstock-Batch',
+    description='Just the stand alone postprocessing functions from Buildstock-Batch',
     py_modules=['postprocessing'],
     install_requires=[
         'dask[complete]',
-        's3fs>=0.4.0',
+        's3fs>=0.4.2,<0.5.0',
         'boto3',
         'pandas>=1.0.0,!=1.0.4',
         'pyarrow>=0.14.1',


### PR DESCRIPTION
## Pull Request Description

The most recent version of s3fs was causing dependency problems in the EMR bootstrap script. This pins it to an older, working version. 

## Checklist

Not all may apply

- [ ] Code changes (must work)
- [x] ~~Tests exercising your feature/bug fix (check coverage report on CircleCI build -> Artifacts)~~
- [x] All other unit tests passing
- [x] ~~Update validation for project config yaml file changes~~
- [x] ~~Update existing documentation~~
- [ ] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
- [ ] Add to the changelog_dev.rst file and propose migration text in the pull request
