### PR TITLE
Making sure docs deployment still works

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,5 +80,5 @@ workflows:
             - build
           filters:
             branches:
-              only: docs_deploy_fix
+              only: develop
 


### PR DESCRIPTION
Fixing Circle CI config so docs deployment still happens. 