### PR TITLE
Set python version to 3.7.8 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           name: Install buildstock
           command: |
             conda install -c conda-forge -y -q scipy numpy "pandas>=1.0.0,!=1.0.4" "pyarrow>=0.14.1" dask joblib pyyaml
-            pip install .[dev] --progress-bar off
+            pip3 install .[dev] --progress-bar off
       - run:
           name: Run PyTest
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,8 @@ jobs:
       - run:
           name: Install buildstock
           command: |
-            conda install -c conda-forge -y -q scipy numpy "pandas>=1.0.0,!=1.0.4" "pyarrow>=0.14.1" dask joblib pyyaml
-            pip3 install .[dev] --progress-bar off
+            conda install -c conda-forge -y -q scipy numpy "pandas>=1.0.0,!=1.0.4" "pyarrow>=0.14.1" dask joblib pyyaml "ruamel.yaml>=0.15.0"
+            pip install .[dev] --progress-bar off
       - run:
           name: Run PyTest
           command: |

--- a/create_eagle_env.sh
+++ b/create_eagle_env.sh
@@ -26,7 +26,7 @@ MY_CONDA_PREFIX="$CONDA_ENVS_DIR/$MY_CONDA_ENV_NAME"
 echo "Creating $MY_CONDA_PREFIX"
 module load conda
 conda remove -y --prefix "$MY_CONDA_PREFIX" --all
-conda create -y --prefix "$MY_CONDA_PREFIX" -c conda-forge "pyarrow>=0.14" python=3.7 "pandas>=1.0.0,!=1.0.4" dask distributed ruby
+conda create -y --prefix "$MY_CONDA_PREFIX" -c conda-forge "pyarrow>=0.14" python=3.7.8 "pandas>=1.0.0,!=1.0.4" dask distributed ruby
 source activate "$MY_CONDA_PREFIX"
 pip install --upgrade pip
 if [ $DEV -eq 1 ]

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setuptools.setup(
         'fsspec>=0.6.0',
         'docutils<0.15,>=0.10',
         'yamale>=2.0',
-        'ruamel_yaml>=0.15.0',
+        'ruamel.yaml>=0.15.0',
         'testfixtures',
         'awsretry',
     ],

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setuptools.setup(
         'fsspec>=0.6.0',
         'docutils<0.15,>=0.10',
         'yamale>=2.0',
-        'ruamel.yaml>=0.15.0',
+        'ruamel_yaml>=0.15.0',
         'testfixtures',
         'awsretry',
     ],


### PR DESCRIPTION
Fixes #194 
## Pull Request Description
Explicitly set python version to 3.7.8 to play nicer with libraries on Eagle (matches current system python on Eagle)