### PR TITLE
Fix/comstock cleanup sim dir failure

### DIFF
--- a/buildstockbatch/base.py
+++ b/buildstockbatch/base.py
@@ -247,7 +247,17 @@ class BuildStockBatchBase(object):
         timeseries_filepath = os.path.join(sim_dir, 'run', 'enduse_timeseries.csv')
         schedules_filepath = os.path.join(sim_dir, 'generated_files', 'schedules.csv')
         if os.path.isfile(timeseries_filepath):
-            tsdf = pd.read_csv(timeseries_filepath, parse_dates=['Time', 'TimeDST', 'TimeUTC'])
+            # Find the time columns present in the enduse_timeseries file
+            possible_time_cols = ['time', 'Time', 'TimeDST', 'TimeUTC']
+            cols = pd.read_csv(timeseries_filepath, index_col=False, nrows=0).columns.tolist()
+            actual_time_cols = []
+            for possible_time_col in possible_time_cols:
+                if possible_time_col in cols:
+                    actual_time_cols.append(possible_time_col)
+            if not actual_time_cols:
+                logger.error(f'Did not find any time column ({possible_time_cols}) in enduse_timeseries.csv.')
+                raise RuntimeError(f'Did not find any time column ({possible_time_cols}) in enduse_timeseries.csv.')
+            tsdf = pd.read_csv(timeseries_filepath, parse_dates=actual_time_cols)
             if os.path.isfile(schedules_filepath):
                 schedules = pd.read_csv(schedules_filepath)
                 schedules.rename(columns=lambda x: f'schedules_{x}', inplace=True)
@@ -399,8 +409,8 @@ class BuildStockBatchBase(object):
                         'TimeseriesCSVExport': 'timeseries_csv_export'
                         }
         if 'reporting_measures' in cfg.keys():
-            for reporting_measure in cfg['reporting_measures']:
-                measure_names[reporting_measure] = 'reporting_measures'
+            for reporting_measure in cfg.get('reporting_measures', []):
+                measure_names[reporting_measure['measure_dir_name']] = 'reporting_measures'
 
         error_msgs = ''
         warning_msgs = ''

--- a/buildstockbatch/base.py
+++ b/buildstockbatch/base.py
@@ -250,10 +250,7 @@ class BuildStockBatchBase(object):
             # Find the time columns present in the enduse_timeseries file
             possible_time_cols = ['time', 'Time', 'TimeDST', 'TimeUTC']
             cols = pd.read_csv(timeseries_filepath, index_col=False, nrows=0).columns.tolist()
-            actual_time_cols = []
-            for possible_time_col in possible_time_cols:
-                if possible_time_col in cols:
-                    actual_time_cols.append(possible_time_col)
+            actual_time_cols = [c for c in cols if c in possible_time_cols]
             if not actual_time_cols:
                 logger.error(f'Did not find any time column ({possible_time_cols}) in enduse_timeseries.csv.')
                 raise RuntimeError(f'Did not find any time column ({possible_time_cols}) in enduse_timeseries.csv.')

--- a/buildstockbatch/base.py
+++ b/buildstockbatch/base.py
@@ -406,8 +406,8 @@ class BuildStockBatchBase(object):
                         'TimeseriesCSVExport': 'timeseries_csv_export'
                         }
         if 'reporting_measures' in cfg.keys():
-            for reporting_measure in cfg.get('reporting_measures', []):
-                measure_names[reporting_measure['measure_dir_name']] = 'reporting_measures'
+            for reporting_measure in cfg['reporting_measures']:
+                measure_names[reporting_measure] = 'reporting_measures'
 
         error_msgs = ''
         warning_msgs = ''


### PR DESCRIPTION
Fixes #200

## Pull Request Description

Allows postprocessing of both ResStock and ComStock by enumerating a list of possible time column names that cover the enduse_timeseries.csv files from both types of workflows.

## Checklist

Not all may apply

- [x] Code changes (must work)
- [x] All other unit tests passing: Tests passed locally, but for some reason circleci didn't run.
- [x] Run a small batch run to make sure it all works: ran a ComStock run locally with docker.