### PR TITLE
replace references to OpenStudio-BuildStock

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,7 +31,7 @@ log file here
 **Platform (please complete the following information):**
 - Simulation platform: [e.g. Eagle, AWS, local docker; please label with this as well]
 - BuildStockBatch version, branch, or sha: 
-- OpenStudio-BuildStock version, branch, or sha:
+- resstock or comstock repo version, branch, or sha:
 - Local Desktop OS: [e.g. Windows, Mac, Linux, especially important if running locally]
 
 **Additional context**

--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 [![CircleCI](https://circleci.com/gh/NREL/buildstockbatch.svg?style=svg&circle-token=4333c59c1b03b3461dfd16798ba04cb26bede4c0)](https://circleci.com/gh/NREL/buildstockbatch)
 
-This set of tools provides an alternative means to PAT to run and manage the
-batch simulations for the
-[ResStock](https://github.com/NREL/OpenStudio-BuildStock) and
+This set of tools provides a means to run and manage batch simulations for the
+[ResStock](https://github.com/NREL/resstock) and
 [ComStock](https://github.com/NREL/comstock) building stock energy models. It
 can be used to run the simulations locally, on Amazon Web Services, or on NREL's
 supercomputers.

--- a/aws_demo_project.yml
+++ b/aws_demo_project.yml
@@ -1,6 +1,6 @@
 schema_version: 0.2
 stock_type: residential
-buildstock_directory: ../OpenStudio-BuildStock  # Relative to this file or absolute
+buildstock_directory: ../resstock  # Relative to this file or absolute
 project_directory: project_national  # Relative to buildstock_directory
 output_directory: ../demo_test_outputs
 weather_files_url: https://data.nrel.gov/system/files/128/ResStock_TMY3.zip

--- a/buildstockbatch/sampler/base.py
+++ b/buildstockbatch/sampler/base.py
@@ -27,8 +27,8 @@ class BuildStockSampler(object):
         due to unique requirements created by the commercial tsv set.
 
         :param cfg: YAML configuration specified by the user for the analysis
-        :param buildstock_dir: The location of the OpenStudio-BuildStock repo
-        :param project_dir: The project directory within the OpenStudio-BuildStock repo
+        :param buildstock_dir: The location of the resstock or comstock repo
+        :param project_dir: The project directory within the resstock or comstock repo
         """
         self.cfg = cfg
         self.buildstock_dir = buildstock_dir

--- a/buildstockbatch/sampler/commercial_sobol.py
+++ b/buildstockbatch/sampler/commercial_sobol.py
@@ -33,8 +33,8 @@ class CommercialBaseSobolSampler(BuildStockSampler):
 
         :param output_dir: Directory in which to place buildstock.csv
         :param cfg: YAML configuration specified by the user for the analysis
-        :param buildstock_dir: The location of the OpenStudio-BuildStock repo
-        :param project_dir: The project directory within the OpenStudio-BuildStock repo
+        :param buildstock_dir: The location of the comstock or resstock repo
+        :param project_dir: The project directory within the comstock or resstock repo
         """
         super().__init__(*args, **kwargs)
         self.output_dir = output_dir

--- a/buildstockbatch/sampler/precomputed.py
+++ b/buildstockbatch/sampler/precomputed.py
@@ -26,8 +26,8 @@ class PrecomputedBaseSampler(BuildStockSampler):
         Initialize the sampler.
 
         :param cfg: YAML configuration specified by the user for the analysis
-        :param buildstock_dir: The location of the OpenStudio-BuildStock repo
-        :param project_dir: The project directory within the OpenStudio-BuildStock repo
+        :param buildstock_dir: The location of the comstock or resstock repo
+        :param project_dir: The project directory within the comstock or resstock repo
         """
         super().__init__(*args, **kwargs)
         self.buildstock_csv = self.cfg['baseline']['precomputed_sample']
@@ -51,8 +51,8 @@ class PrecomputedSingularitySampler(PrecomputedBaseSampler):
 
         :param output_dir: Simulation working directory
         :param cfg: YAML configuration specified by the user for the analysis
-        :param buildstock_dir: The location of the OpenStudio-BuildStock repo
-        :param project_dir: The project directory within the OpenStudio-BuildStock repo
+        :param buildstock_dir: The location of the comstock or resstock repo
+        :param project_dir: The project directory within the comstock or resstock repo
         """
         super().__init__(*args, **kwargs)
         self.csv_path = os.path.join(output_dir, 'housing_characteristics', 'buildstock.csv')
@@ -65,8 +65,8 @@ class PrecomputedDockerSampler(PrecomputedBaseSampler):
         Initialize the sampler.
 
         :param cfg: YAML configuration specified by the user for the analysis
-        :param buildstock_dir: The location of the OpenStudio-BuildStock repo
-        :param project_dir: The project directory within the OpenStudio-BuildStock repo
+        :param buildstock_dir: The location of the comstock or resstock repo
+        :param project_dir: The project directory within the comstock or resstock repo
         """
         super().__init__(*args, **kwargs)
         self.csv_path = os.path.join(self.project_dir, 'housing_characteristics', 'buildstock.csv')

--- a/buildstockbatch/sampler/residential_singularity.py
+++ b/buildstockbatch/sampler/residential_singularity.py
@@ -29,8 +29,8 @@ class ResidentialSingularitySampler(BuildStockSampler):
         :param singularity_image: path to the singularity image to use
         :param output_dir: Simulation working directory
         :param cfg: YAML configuration specified by the user for the analysis
-        :param buildstock_dir: The location of the OpenStudio-BuildStock repo
-        :param project_dir: The project directory within the OpenStudio-BuildStock repo
+        :param buildstock_dir: The location of the resstock or comstock repo
+        :param project_dir: The project directory within the resstock or comstock repo
         """
         super().__init__(*args, **kwargs)
         self.singularity_image = singularity_image

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -14,3 +14,10 @@ Development Changelog
         This is an example change. Please copy and paste it - for valid tags please refer to ``conf.py`` in the docs
         directory. ``pullreq`` should be set to the appropriate pull request number and ``tickets`` to any related
         github issues. These will be automatically linked in the documentation.
+
+    .. change::
+        :tags: documentation
+        :pullreq: 203
+
+        https://github.com/NREL/OpenStudio-BuildStock was renamed to https://github.com/NREL/resstock so references to 
+        OpenStudio-BuildStock in docs were replaced with references to resstock and/or comstock.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,10 +6,10 @@
 BuildStock Batch
 ================
 
-This set of tools provides an alternative means to PAT to run and manage the batch
+This set of tools provides a means to run and manage the batch
 simulations for the
-`OpenStudio-BuildStock <https://github.com/NREL/OpenStudio-BuildStock>`__
-building stock energy modeling platform. It can be used to run the
+`ResStock <https://github.com/NREL/resstock>`__
+and `ComStock <https://github.com/NREL/comstock>`__ building stock energy modeling platforms. It can be used to run the
 simulations locally, on Amazon Web Services (beta), or on NREL's
 supercomputer, Eagle.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -2,7 +2,7 @@ Installation
 ------------
 
 BuildStock-Batch installations depend on the
-`OpenStudio-BuildStock <https://github.com/NREL/OpenStudio-BuildStock>`__
+`ResStock <https://github.com/NREL/resstock>`__
 repository. Either ``git clone`` it or download a copy of it or your
 fork or branch of it with your projects.
 

--- a/docs/project_defn.rst
+++ b/docs/project_defn.rst
@@ -2,7 +2,7 @@ Project Definition
 ------------------
 
 Most of the project definition happens in a project folder in the
-checked out copy of OpenStudio-BuildStock. However, for this library to
+checked out copy of the resstock or comstock repo. However, for this library to
 work, a separate project YAML file provides the details needed for the
 batch run. An example file is in this repo as
 ``project_resstock_national.yml`` as shown below.
@@ -17,13 +17,13 @@ Reference the project
 
 First we tell it what project we're running with the following keys:
 
-- ``buildstock_directory``: The absolute (or relative to this YAML file) path of the `OpenStudio-BuildStock`_
+- ``buildstock_directory``: The absolute (or relative to this YAML file) path of the `ResStock`_
   repository.
 - ``project_directory``: The relative (to the ``buildstock_directory``) path of the project.
 - ``schema_version``: The version of the project yaml file to use and validate - currently the minimum version is
   ``0.2``.
 
-.. _OpenStudio-BuildStock: https://github.com/NREL/OpenStudio-BuildStock
+.. _ResStock: https://github.com/NREL/resstock
 
 Weather Files
 ~~~~~~~~~~~~~
@@ -45,9 +45,9 @@ Custom Weather Files
 
 To use your own custom weather files for a specific location, this can be done in **one** of two ways:
 
-- Rename the filename references in your local `options_lookup.tsv <https://github.com/NREL/OpenStudio-BuildStock/blob/master/resources/options_lookup.tsv>`_ in the ``resources`` folder to match your custom weather file names. For example, in the options_lookup tsv, the Location ``AL_Birmingham.Muni.AP.722280`` is matched to the ``weather_file_name=USA_AL_Birmingham.Muni.AP.722280.epw``. To update the weather file for this location, the `weather_file_name` field needs to be updated to match your new name specified.
+- Rename the filename references in your local `options_lookup.tsv <https://github.com/NREL/resstock/blob/master/resources/options_lookup.tsv>`_ in the ``resources`` folder to match your custom weather file names. For example, in the options_lookup tsv, the Location ``AL_Birmingham.Muni.AP.722280`` is matched to the ``weather_file_name=USA_AL_Birmingham.Muni.AP.722280.epw``. To update the weather file for this location, the `weather_file_name` field needs to be updated to match your new name specified.
 
-- Rename your custom .epw weather file to match the references in your local `options_lookup.tsv <https://github.com/NREL/OpenStudio-BuildStock/blob/master/resources/options_lookup.tsv>`_ in the ``resources`` folder.
+- Rename your custom .epw weather file to match the references in your local `options_lookup.tsv <https://github.com/NREL/resstock/blob/master/resources/options_lookup.tsv>`_ in the ``resources`` folder.
 
 Baseline simulations incl. sampling algorithm
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -92,7 +92,7 @@ Residential Simulation Controls
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If the key ``residential_simulation_controls`` is in the project yaml file, the parameters to the
-`ResidentialSimulationControls <https://github.com/NREL/OpenStudio-BuildStock/blob/master/measures/ResidentialSimulationControls/measure.xml>`_
+`ResidentialSimulationControls <https://github.com/NREL/resstock/blob/master/measures/ResidentialSimulationControls/measure.xml>`_
 measure will be modified from their defaults to what is specified there. The defaults are:
 
 .. include:: ../buildstockbatch/workflow_generator/residential.py
@@ -112,8 +112,8 @@ following properties:
 -  ``options``: A list of options to apply as part of this upgrade.
 
    -  ``option``: (required) The option to apply, in the format ``parameter|option`` which can be found in
-      `options_lookup.tsv <https://github.com/NREL/OpenStudio-BuildStock/blob/master/resources/options_lookup.tsv>`_
-      in `OpenStudio-BuildStock`_.
+      `options_lookup.tsv <https://github.com/NREL/resstock/blob/master/resources/options_lookup.tsv>`_
+      in `ResStock`_.
    -  ``apply_logic``: Logic that defines which buildings to apply the upgrade to. See
       :ref:`filtering-logic` for instructions.
    - ``costs``: A list of costs for the upgrade.
@@ -124,7 +124,7 @@ following properties:
           Since there can be multiple costs, this permits both fixed and variable costs for upgrades
           that depend on the properties of the baseline building.
           The multiplier needs to be from
-          `this enumeration list in OpenStudio-BuildStock <https://github.com/NREL/OpenStudio-BuildStock/blob/master/measures/ApplyUpgrade/measure.rb#L71-L87>`_
+          `this enumeration list inthe resstock or comstock repo <https://github.com/NREL/resstock/blob/master/measures/ApplyUpgrade/measure.rb#L71-L87>`_
           or from the list in your branch of that repo.
    - ``lifetime``: Lifetime in years of the upgrade.
 
@@ -140,9 +140,9 @@ Simulation Annual Outputs Options
 
 Include the ``simulation_output`` key to optionally include annual totals for end use subcategories (i.e., interior equipment broken out by end use) along with
 the usual annual simulation results. This argument is passed directly into the
-`SimulationOutputReport measure <https://github.com/NREL/OpenStudio-BuildStock/blob/master/measures/SimulationOutputReport/measure.xml>`_
-in OpenStudio-BuildStock. Please refer to the measure argument there to determine what to set it to in your config file.
-Note that this measure and presence of any arguments may be different depending on which version of OpenStudio-BuildStock you're using.
+`SimulationOutputReport measure <https://github.com/NREL/resstock/blob/master/measures/SimulationOutputReport/measure.xml>`_
+inthe resstock or comstock repo. Please refer to the measure argument there to determine what to set it to in your config file.
+Note that this measure and presence of any arguments may be different depending on which version ofthe resstock or comstock repo you're using.
 The best thing you can do is to verify that it works with what is in your branch.
 
 Time Series Export Options
@@ -150,9 +150,9 @@ Time Series Export Options
 
 Include the ``timeseries_csv_export`` key to include hourly or subhourly results along with the usual
 annual simulation results. These arguments are passed directly to the
-`TimeseriesCSVExport measure <https://github.com/NREL/OpenStudio-BuildStock/blob/master/measures/TimeseriesCSVExport/measure.xml>`_
-in OpenStudio-BuildStock. Please refer to the measure arguments there to determine what to set them to in your config file.
-Note that this measure and arguments may be different depending on which version of OpenStudio-BuildStock you're using.
+`TimeseriesCSVExport measure <https://github.com/NREL/resstock/blob/master/measures/TimeseriesCSVExport/measure.xml>`_
+inthe resstock or comstock repo. Please refer to the measure arguments there to determine what to set them to in your config file.
+Note that this measure and arguments may be different depending on which version ofthe resstock or comstock repo you're using.
 The best thing you can do is to verify that it works with what is in your branch.
 
 Additional Reporting Measures
@@ -389,7 +389,7 @@ follows:
    For ResStock runs with the ResidentialScheduleGenerator, the generated schedules
    are horizontally concatenated with the time series files before aggregation,
    making sure the schedule values are properly lined up with the timestamps in the
-   `same way that Energeyplus handles ScheduleFiles <https://github.com/NREL/OpenStudio-BuildStock/issues/469#issuecomment-697849076>`_.
+   `same way that Energeyplus handles ScheduleFiles <https://github.com/NREL/resstock/issues/469#issuecomment-697849076>`_.
    
 
 Uploading to AWS Athena

--- a/project_resstock_multifamily.yml
+++ b/project_resstock_multifamily.yml
@@ -1,5 +1,5 @@
 schema_version: 0.2
-buildstock_directory: ../OpenStudio-BuildStock  # Relative to this file or absolute
+buildstock_directory: ../resstock  # Relative to this file or absolute
 project_directory: project_resstock_multifamily  # Relative to buildstock_directory
 weather_files_path: /projects/res_stock/project_resstock_national_weather.zip  # Relative to this file or absolute path to zipped weather files
 baseline:

--- a/project_resstock_national.yml
+++ b/project_resstock_national.yml
@@ -1,6 +1,6 @@
 schema_version: 0.2
 stock_type: residential
-buildstock_directory: ../OpenStudio-BuildStock  # Relative to this file or absolute
+buildstock_directory: ../resstock  # Relative to this file or absolute
 project_directory: project_national  # Relative to buildstock_directory
 output_directory: ../national_test_outputs
 weather_files_url: https://data.nrel.gov/system/files/128/ResStock_TMY3.zip

--- a/project_resstock_national_upgrades.yml
+++ b/project_resstock_national_upgrades.yml
@@ -1,5 +1,5 @@
 schema_version: 0.2
-buildstock_directory: ../OpenStudio-BuildStock  # Relative to this file or absolute
+buildstock_directory: ../resstock  # Relative to this file or absolute
 project_directory: project_resstock_heterogeneity  # Relative to buildstock_directory
 output_directory: /scratch/nmerket/heterogeneity4
 #weather_files_url: https://s3.amazonaws.com/epwweatherfiles/project_resstock_national.zip


### PR DESCRIPTION
Fixes # .

## Pull Request Description

https://github.com/NREL/OpenStudio-BuildStock was renamed to https://github.com/NREL/resstock. This PR replaces references to `OpenStudio-BuildStock` with references to resstock and/or comstock. I wasn't sure how to handle the references in `buildstockbatch/test/test_inputs/*.yml` (e.g., "/home/epresent/OpenStudio-BuildStock-master")

## Checklist

Not all may apply

- [n/a] Code changes (must work)
- [ ] Tests exercising your feature/bug fix (check coverage report on CircleCI build -> Artifacts)
- [ ] All other unit tests passing
- [ ] Update validation for project config yaml file changes
- [x] Update existing documentation
- [ ] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
- [x] Add to the changelog_dev.rst file and propose migration text in the pull request
