### PR TITLE
Remove data_point.zip from outputs

### DIFF
--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -121,14 +121,14 @@ def read_job_files(fs, started, finished):
             started_at = re.search(r'Started Workflow (.*\s.*?)\s', f.readline()).group(1)
             started_at = dt.datetime.strptime(started_at, '%Y-%m-%d %H:%M:%S')
             jobs['started_at'] = started_at.strftime('%Y%m%dT%H%M%SZ')
-    except:
+    except (FileNotFoundError):
         return None
     try:
         with fs.open(finished, 'r') as f:
             completed_at = re.search(r'Finished Workflow (.*\s.*?)\s', f.readline()).group(1)
             completed_at = dt.datetime.strptime(completed_at, '%Y-%m-%d %H:%M:%S')
             jobs['completed_at'] = completed_at.strftime('%Y%m%dT%H%M%SZ')
-    except:
+    except (FileNotFoundError):
         return None
     else:
         jobs['completed_status'] = 'Success'
@@ -161,7 +161,7 @@ def read_simulation_outputs(fs, reporting_measures, sim_dir, upgrade_id, buildin
     out_osw = read_out_osw(fs, f'{sim_dir}/out.osw')
     if out_osw:
         dpout.update(out_osw)
-    else: # for when run_options: fast=true
+    else:  # for when run_options: fast=true
         jobs = read_job_files(fs, f'{sim_dir}/run/started.job', f'{sim_dir}/run/finished.job')
         dpout.update(jobs)
     dpout['upgrade'] = upgrade_id

--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -50,7 +50,7 @@ def read_data_point_out_json(fs, reporting_measures, filename):
     if 'SimulationOutputReport' not in d:
         d['SimulationOutputReport'] = {'applicable': False, 'completed_status': 'Invalid'}
     else:
-        d['SimulationOutputReport'] = {'completed_status': 'Fail'}
+        d['SimulationOutputReport']['completed_status'] = 'Fail'
     for reporting_measure in reporting_measures:
         if reporting_measure not in d:
             d[reporting_measure] = {'applicable': False}

--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -122,14 +122,14 @@ def read_job_files(fs, started, finished):
             started_at = dt.datetime.strptime(started_at, '%Y-%m-%d %H:%M:%S')
             jobs['started_at'] = started_at.strftime('%Y%m%dT%H%M%SZ')
     except (FileNotFoundError):
-        return None
+        return jobs
     try:
         with fs.open(finished, 'r') as f:
             completed_at = re.search(r'Finished Workflow (.*\s.*?)\s', f.readline()).group(1)
             completed_at = dt.datetime.strptime(completed_at, '%Y-%m-%d %H:%M:%S')
             jobs['completed_at'] = completed_at.strftime('%Y%m%dT%H%M%SZ')
     except (FileNotFoundError):
-        return None
+        return jobs
     else:
         jobs['completed_status'] = 'Success'
     return jobs

--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -48,8 +48,10 @@ def read_data_point_out_json(fs, reporting_measures, filename):
             return None
 
     if 'SimulationOutputReport' not in d:
-        d['SimulationOutputReport'] = {'applicable': False}
-    for reporting_measure in reporting_measures + ['UpgradeCosts']:
+        d['SimulationOutputReport'] = {'applicable': False, 'completed_status': 'Invalid'}
+    else:
+        d['SimulationOutputReport'] = {'completed_status': 'Fail'}
+    for reporting_measure in reporting_measures:
         if reporting_measure not in d:
             d[reporting_measure] = {'applicable': False}
     return d
@@ -93,6 +95,9 @@ def flatten_datapoint_json(reporting_measures, d):
     new_d['building_id'] = new_d['BuildExistingModel.building_id']
     del new_d['BuildExistingModel.building_id']
 
+    new_d['completed_status'] = new_d['SimulationOutputReport.completed_status']
+    del new_d['SimulationOutputReport.completed_status']
+
     return new_d
 
 
@@ -114,25 +119,25 @@ def read_out_osw(fs, filename):
         return out_d
 
 
-def read_job_files(fs, started, finished):
-    jobs = {'completed_status': 'Fail'}
+def read_job_files(fs, dpout, started, finished):
     try:
         with fs.open(started, 'r') as f:
             started_at = re.search(r'Started Workflow (.*\s.*?)\s', f.readline()).group(1)
             started_at = dt.datetime.strptime(started_at, '%Y-%m-%d %H:%M:%S')
-            jobs['started_at'] = started_at.strftime('%Y%m%dT%H%M%SZ')
+            dpout['started_at'] = started_at.strftime('%Y%m%dT%H%M%SZ')
     except (FileNotFoundError):
-        return jobs
+        return dpout
     try:
         with fs.open(finished, 'r') as f:
             completed_at = re.search(r'Finished Workflow (.*\s.*?)\s', f.readline()).group(1)
             completed_at = dt.datetime.strptime(completed_at, '%Y-%m-%d %H:%M:%S')
-            jobs['completed_at'] = completed_at.strftime('%Y%m%dT%H%M%SZ')
+            dpout['completed_at'] = completed_at.strftime('%Y%m%dT%H%M%SZ')
     except (FileNotFoundError):
-        return jobs
+        return dpout
     else:
-        jobs['completed_status'] = 'Success'
-    return jobs
+        if dpout['completed_status'] != 'Invalid':
+            dpout['completed_status'] = 'Success'
+    return dpout
 
 
 def read_simulation_outputs(fs, reporting_measures, sim_dir, upgrade_id, building_id):
@@ -162,8 +167,7 @@ def read_simulation_outputs(fs, reporting_measures, sim_dir, upgrade_id, buildin
     if out_osw:
         dpout.update(out_osw)
     else:  # for when run_options: fast=true
-        jobs = read_job_files(fs, f'{sim_dir}/run/started.job', f'{sim_dir}/run/finished.job')
-        dpout.update(jobs)
+        dpout = read_job_files(fs, dpout, f'{sim_dir}/run/started.job', f'{sim_dir}/run/finished.job')
     dpout['upgrade'] = upgrade_id
     dpout['building_id'] = building_id
     return dpout

--- a/buildstockbatch/test/test_eagle.py
+++ b/buildstockbatch/test/test_eagle.py
@@ -7,6 +7,7 @@ import requests
 import shutil
 import tarfile
 from unittest.mock import patch
+from unittest import TestCase
 import gzip
 
 from buildstockbatch.eagle import user_cli, EagleBatch
@@ -234,18 +235,22 @@ def test_run_building_process(mocker,  basic_residential_project_file):
     b.run_job_batch(1)
 
     # check results job-json
-    refrence_path = pathlib.Path(__file__).resolve().parent / 'test_results' / 'reference_files'
+    reference_path = pathlib.Path(__file__).resolve().parent / 'test_results' / 'reference_files'
 
-    refrence_list = json.loads(gzip.open(refrence_path / 'results_job1.json.gz', 'r').read())
+    reference_list = sorted(
+        json.loads(gzip.open(reference_path / 'results_job1.json.gz', 'r').read()),
+        key=lambda x: (x['upgrade'], x['building_id'])
+    )
 
-    output_list = json.loads(gzip.open(results_dir / 'simulation_output' / 'results_job1.json.gz', 'r').read())
+    output_list = sorted(
+        json.loads(gzip.open(results_dir / 'simulation_output' / 'results_job1.json.gz', 'r').read()),
+        key=lambda x: (x['upgrade'], x['building_id'])
+    )
 
-    refrence_list = [json.dumps(d) for d in refrence_list]
-    output_list = [json.dumps(d) for d in output_list]
+    for x, y in zip(reference_list, output_list):
+        TestCase().assertDictEqual(x, y)
 
-    assert sorted(refrence_list) == sorted(output_list)
-
-    ts_files = list(refrence_path.glob('**/*.parquet'))
+    ts_files = list(reference_path.glob('**/*.parquet'))
 
     def compare_ts_parquets(source, dst):
         test_pq = pd.read_parquet(source).reset_index().drop(columns=['index'])

--- a/buildstockbatch/workflow_generator/commercial.py
+++ b/buildstockbatch/workflow_generator/commercial.py
@@ -88,7 +88,12 @@ class CommercialDefaultWorkflowGenerator(WorkflowGeneratorBase):
             'measure_paths': [
                 'measures'
             ],
-            'weather_file': 'weather/empty.epw'
+            'weather_file': 'weather/empty.epw',
+            'run_options': {
+                'fast': True,
+                'skip_expand_objects': True,
+                'skip_energyplus_preprocess': True
+            }
         }
 
         osw['steps'].extend(workflow_args['measures'])

--- a/buildstockbatch/workflow_generator/residential.py
+++ b/buildstockbatch/workflow_generator/residential.py
@@ -269,6 +269,11 @@ class ResidentialDefaultWorkflowGenerator(WorkflowGeneratorBase):
             'measure_paths': [
                 'measures'
             ],
+            'run_options': {
+                'fast': True,
+                'skip_expand_objects': True,
+                'skip_energyplus_preprocess': True
+            }
         }
 
         osw['steps'].extend(workflow_args['measures'])

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -75,3 +75,11 @@ Development Changelog
         :tickets: 189
 
         Adding measure arguments for reporting measures in the workflow generator.
+
+    .. change::
+        :tags: workflow
+        :pullreq: 220
+        :tickets: 
+
+        Use ``run_options`` in residential and commercial workflow generators.
+        Remove data_point.zip from outputs.


### PR DESCRIPTION
## Pull Request Description

Adds to generated osw files:
```
'run_options': {
    'fast': True,
    'skip_expand_objects': True,
    'skip_energyplus_preprocess': True
}
```

This removes the `data_point.zip` layer. Then, we must read from `results.json` instead of `data_point_out.json`. We must also get `started_at` and `completed_at` timestamps from `started.job` and `finished.job` instead of `out.osw`.

How do we get `completed_status`? Specifically, `completed_status=Invalid`? Answer: by looking at the presence of `SimulationOutputReport` in the `results.json`. If it's not there, then the datapoint is "Invalid".

## Checklist

Not all may apply

- [ ] Code changes (must work)
- [ ] Tests exercising your feature/bug fix (check coverage report on CircleCI build -> Artifacts)
- [ ] All other unit tests passing
- [ ] Update validation for project config yaml file changes
- [ ] Update existing documentation
- [ ] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
- [ ] Add to the changelog_dev.rst file and propose migration text in the pull request
