### PR TITLE
Writing parquet files with newer datetime format

### DIFF
--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -147,7 +147,7 @@ def read_simulation_outputs(fs, reporting_measures, sim_dir, upgrade_id, buildin
 def write_dataframe_as_parquet(df, fs, filename):
     tbl = pa.Table.from_pandas(df, preserve_index=False)
     with fs.open(filename, 'wb') as f:
-        parquet.write_table(tbl, f, flavor='spark')
+        parquet.write_table(tbl, f)
 
 
 def clean_up_results_df(df, cfg, keep_upgrade_id=False):

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -60,3 +60,11 @@ Development Changelog
         The glue crawler was failing when there was a trailing ``/`` character.
         This fixes that as well as checks to make sure files were uploaded
         before running the crawler.
+
+    .. change::
+        :tags: bugfix
+        :pullreq: 224
+        :tickets: 221
+
+        Defaults to the newer datetime encoding in the parquet files now that
+        Athena can understand it.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -53,9 +53,11 @@ configure your user account with your AWS credentials. This setup only needs to 
 
 1. `Install the AWS CLI`_ version 2 (select the version for your local OS; not for Docker).
 2. `Configure the AWS CLI`_. (Don't type the ``$`` in the example.)
+3. You may need to `change the Athena Engine version`_ for your query workgroup to v2.
 
 .. _Install the AWS CLI: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html
 .. _Configure the AWS CLI: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html#cli-quick-configuration
+.. _change the Athena Engine version: https://docs.aws.amazon.com/athena/latest/ug/engine-versions-changing.html
 
 .. _eagle_install:
 


### PR DESCRIPTION
Fixes #221.

## Pull Request Description

Removes the `flavor='spark'` from postprocessing.py as it no longer does what was intended and isn't necessary given Athena can understand the new datetime format.

I have run a small test with this and confirmed that Athena properly interprets the datetime fields.

## Checklist

Not all may apply

- [x] Code changes (must work)
- [x] ~~Tests exercising your feature/bug fix (check coverage report on CircleCI build -> Artifacts)~~
- [x] All other unit tests passing
- [x] ~~Update validation for project config yaml file changes~~
- [x] Update existing documentation
- [x] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
- [x] Add to the changelog_dev.rst file and propose migration text in the pull request
