### PR TITLE
Fix for activating environment and installing packages properly

### DIFF
--- a/create_eagle_env.sh
+++ b/create_eagle_env.sh
@@ -27,11 +27,12 @@ echo "Creating $MY_CONDA_PREFIX"
 module load conda
 conda remove -y --prefix "$MY_CONDA_PREFIX" --all
 conda create -y --prefix "$MY_CONDA_PREFIX" -c conda-forge "pyarrow>=3.0.0" python=3.7.8 "numpy>=1.20.0" "pandas>=1.0.0,!=1.0.4" dask distributed ruby
+source deactivate 
 source activate "$MY_CONDA_PREFIX"
-pip install --upgrade pip
+which pip
 if [ $DEV -eq 1 ]
 then
-    pip install -e .
+    pip install --ignore-installed -e .
 else
-    pip install .
+    pip install --ignore-installed .
 fi

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -77,7 +77,7 @@ Development Changelog
         Adding measure arguments for reporting measures in the workflow generator.
 
     .. change::
-        :tags: general, egale
+        :tags: general, eagle
         :pullreq: 226
         :tickets:
 

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -75,3 +75,10 @@ Development Changelog
         :tickets: 189
 
         Adding measure arguments for reporting measures in the workflow generator.
+
+    .. change::
+        :tags: general, egale
+        :pullreq: 226
+        :tickets:
+
+        Fix for create_eagle_env.sh not creating environment.


### PR DESCRIPTION
This fixes the ongoing issue where the environment is not properly created in eagle.

## Pull Request Description

For some reason, if you run "module load conda" when an environment is already activated, the environment silently gets deactivated. And it can't be activated again by "source activate <path_to_env>" unless it is deactivated explicitly fist.

Evidence:

```
<log in to eagle>
[radhikar@el3 ~]$ which python
/nopt/nrel/apps/anaconda/mini_py37_4.8.3/bin/python
[radhikar@el3 ~]$ source activate /shared-projects/buildstock/envs/test_env6
(test_env6) [radhikar@el3 ~]$ which python
/shared-projects/buildstock/envs/test_env6/bin/python
<environment is activated>
(test_env6) [radhikar@el3 ~]$ module load conda
(test_env6) [radhikar@el3 ~]$ which python 
/nopt/nrel/apps/anaconda/mini_py37_4.8.3/bin/python
<environment got silently deactivated>
(test_env6) [radhikar@el3 ~]$ source activate /shared-projects/buildstock/envs/test_env6
(test_env6) [radhikar@el3 ~]$ which python
/nopt/nrel/apps/anaconda/mini_py37_4.8.3/bin/python
 <environment failed to get activated again>
(test_env6) [radhikar@el3 ~]$ source activate /shared-projects/buildstock/envs/test_env6
(test_env6) [radhikar@el3 ~]$ which python 
/nopt/nrel/apps/anaconda/mini_py37_4.8.3/bin/python
<environment failed to get activated again>
(test_env6) [radhikar@el3 ~]$ source deactivate
DeprecationWarning: 'source deactivate' is deprecated. Use 'conda deactivate'.
[radhikar@el3 ~]$ source activate /shared-projects/buildstock/envs/test_env6
(test_env6) [radhikar@el3 ~]$ which python
/shared-projects/buildstock/envs/test_env6/bin/python
<environment can be activated again after explicit deactivation>
```


## Checklist

Not all may apply

- [x] Code changes (must work)
- [x] Tests exercising your feature/bug fix (check coverage report on CircleCI build -> Artifacts)
- [x] All other unit tests passing
- [x] Update validation for project config yaml file changes
- [x] Update existing documentation
- [x] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
- [x] Add to the changelog_dev.rst file and propose migration text in the pull request
