### PR TITLE
Adding default n_workers to docs

### DIFF
--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -82,3 +82,11 @@ Development Changelog
         :tickets:
 
         Fix for create_eagle_env.sh not creating environment.
+
+    .. change:
+        :tags: documentation
+        :pullreq: 229
+        :tickets: 225
+
+        Modifies docs to specify that the ``eagle.postprocessing.n_workers`` key
+        is for how many Eagle nodes are used and indicates the default of 2.

--- a/docs/project_defn.rst
+++ b/docs/project_defn.rst
@@ -144,7 +144,7 @@ the Eagle supercomputer.
 *  ``postprocessing``: Eagle configuration for the postprocessing step
 
     *  ``time``: Maximum time in minutes to allocate postprocessing job
-    *  ``n_workers``: Number of eagle workers to parallelize the postprocessing job into. Max supported is 32.
+    *  ``n_workers``: Number of eagle nodes to parallelize the postprocessing job into. Max supported is 32. Default is 2.
     *  ``node_memory_mb``: The memory (in MB) to request for eagle node for postprocessing. The valid values are
                            85248, 180224 and 751616. Default is 85248.
     *  ``parquet_memory_mb``: The size (in MB) of the combined parquet file in memory. Default is 40000.


### PR DESCRIPTION
Fixes #225.

## Pull Request Description

Modifies docs to specify that the `eagle.postprocessing.n_workers` key is for how many Eagle _nodes_ are used and indicates the default of 2. 

## Checklist

Not all may apply

- [x] ~~Code changes (must work)~~
- [x] ~~Tests exercising your feature/bug fix (check coverage report on CircleCI build -> Artifacts)~~
- [x] All other unit tests passing
- [x] ~~Update validation for project config yaml file changes~~
- [x] Update existing documentation
- [x] ~~Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)~~
- [x] Add to the changelog_dev.rst file and propose migration text in the pull request
