### PR TITLE
Revert "pinning click<8"

### DIFF
--- a/buildstockbatch/aws/s3_assets/bootstrap-dask-custom
+++ b/buildstockbatch/aws/s3_assets/bootstrap-dask-custom
@@ -44,7 +44,6 @@ python=3.7 \
 "pyarrow>=3.0.0" \
 "s3fs>=0.4.2,<0.5.0" \
 "numpy>=1.20.0" \
-"click<8.0.0"  # remove later
 conda-pack \
 tornado=5 
 

--- a/buildstockbatch/aws/s3_assets/bootstrap-dask-custom
+++ b/buildstockbatch/aws/s3_assets/bootstrap-dask-custom
@@ -39,7 +39,9 @@ conda install \
 -y \
 -q \
 python=3.7 \
-"dask-yarn>=0.7.0" \
+"dask>=2021.5" \
+"distributed>=2021.5" \
+"dask-yarn>=0.9.0" \
 "pandas>=1.0.0,!=1.0.4" \
 "pyarrow>=3.0.0" \
 "s3fs>=0.4.2,<0.5.0" \

--- a/buildstockbatch/aws/s3_assets/setup_postprocessing.py
+++ b/buildstockbatch/aws/s3_assets/setup_postprocessing.py
@@ -6,7 +6,7 @@ setup(
     description='Just the stand alone postprocessing functions from Buildstock-Batch',
     py_modules=['postprocessing'],
     install_requires=[
-        'dask[complete]',
+        'dask[complete]>=2021.5',
         's3fs>=0.4.2,<0.5.0',
         'boto3',
         'pandas>=1.0.0,!=1.0.4',

--- a/create_eagle_env.sh
+++ b/create_eagle_env.sh
@@ -26,7 +26,7 @@ MY_CONDA_PREFIX="$CONDA_ENVS_DIR/$MY_CONDA_ENV_NAME"
 echo "Creating $MY_CONDA_PREFIX"
 module load conda
 conda remove -y --prefix "$MY_CONDA_PREFIX" --all
-conda create -y --prefix "$MY_CONDA_PREFIX" -c conda-forge "pyarrow>=3.0.0" python=3.7.8 "numpy>=1.20.0" "pandas>=1.0.0,!=1.0.4" dask distributed ruby "click<8.0.0"  # Remove click after this is fixed https://github.com/dask/distributed/issues/4817
+conda create -y --prefix "$MY_CONDA_PREFIX" -c conda-forge "pyarrow>=3.0.0" python=3.7.8 "numpy>=1.20.0" "pandas>=1.0.0,!=1.0.4" dask distributed ruby
 source deactivate 
 source activate "$MY_CONDA_PREFIX"
 which pip

--- a/create_eagle_env.sh
+++ b/create_eagle_env.sh
@@ -26,7 +26,7 @@ MY_CONDA_PREFIX="$CONDA_ENVS_DIR/$MY_CONDA_ENV_NAME"
 echo "Creating $MY_CONDA_PREFIX"
 module load conda
 conda remove -y --prefix "$MY_CONDA_PREFIX" --all
-conda create -y --prefix "$MY_CONDA_PREFIX" -c conda-forge "pyarrow>=3.0.0" python=3.7.8 "numpy>=1.20.0" "pandas>=1.0.0,!=1.0.4" dask distributed ruby
+conda create -y --prefix "$MY_CONDA_PREFIX" -c conda-forge "pyarrow>=3.0.0" python=3.7.8 "numpy>=1.20.0" "pandas>=1.0.0,!=1.0.4" "dask>=2021.5" "distributed>=2021.5" ruby
 source deactivate 
 source activate "$MY_CONDA_PREFIX"
 which pip

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -14,3 +14,13 @@ Development Changelog
         This is an example change. Please copy and paste it - for valid tags please refer to ``conf.py`` in the docs
         directory. ``pullreq`` should be set to the appropriate pull request number and ``tickets`` to any related
         github issues. These will be automatically linked in the documentation.
+
+    .. change::
+        :tags: bugfix
+        :pullreq: 232
+        :tickets: 
+
+        There was a few days there when the version of some sublibrary (click)
+        of dask was incompatible with the latest version of dask. We temporarily
+        pinned the sublibrary so that new installs would work. They have fixed
+        that problem now, so this removes the restriction on that library. 

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setuptools.setup(
         'pandas>=1.0.0,!=1.0.4',
         'joblib',
         'pyarrow>=3.0.0',
-        'dask[complete]>=2.1.0',
+        'dask[complete]>=2021.5',
         'docker',
         'boto3>=1.10.44',
         's3fs>=0.4.0,<0.5.0',

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ setuptools.setup(
         'ruamel.yaml>=0.15.0',
         'testfixtures',
         'awsretry',
-        'click<8.0'  # remove this after this bug is fixed in dask https://github.com/dask/distributed/issues/4817
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
This reverts commit d35397bdb7039e165ccf0583baf5fd27968b9256.

## Pull Request Description

We pinned an old version of click which was causing a dependency conflict in dask.distributed.
https://github.com/dask/distributed/issues/4817

This undoes that as the [latest version of dask.distributed 2021.5.0](https://pypi.org/project/distributed/2021.5.0/) fixes that issue. 

## Checklist

Not all may apply

- [x] Code changes (must work)
- [x] ~~Tests exercising your feature/bug fix (check coverage report on CircleCI build -> Artifacts)~~
- [x] All other unit tests passing
- [x] ~~Update validation for project config yaml file changes~~
- [x] ~~Update existing documentation~~
- [x] Create an Eagle environment
- [x] Run a small batch run on Eagle to make sure it all works
- [x] Add to the changelog_dev.rst file and propose migration text in the pull request
