### PR TITLE
Switch source activate to conda deactivate

### DIFF
--- a/create_eagle_env.sh
+++ b/create_eagle_env.sh
@@ -27,7 +27,7 @@ echo "Creating $MY_CONDA_PREFIX"
 module load conda
 conda remove -y --prefix "$MY_CONDA_PREFIX" --all
 conda create -y --prefix "$MY_CONDA_PREFIX" -c conda-forge "pyarrow>=3.0.0" python=3.7.8 "numpy>=1.20.0" "pandas>=1.0.0,!=1.0.4" dask distributed ruby "click<8.0.0"  # Remove click after this is fixed https://github.com/dask/distributed/issues/4817
-source deactivate 
+conda deactivate 
 source activate "$MY_CONDA_PREFIX"
 which pip
 if [ $DEV -eq 1 ]


### PR DESCRIPTION
## Pull Request Description

When I created a developers environment on Eagle, I noticed the warning below.

`DeprecationWarning: 'source deactivate' is deprecated. Use 'conda deactivate'.

In the `create_eagle_env.sh`, I updated the `source deactivate` to `conda deactivate`.

## Checklist

Not all may apply

- [ ] Code changes (must work)
- [ ] Tests exercising your feature/bug fix (check coverage report on CircleCI build -> Artifacts)
- [ ] All other unit tests passing
- [ ] Update validation for project config yaml file changes
- [ ] Update existing documentation
- [ ] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
- [ ] Add to the changelog_dev.rst file and propose migration text in the pull request
