### PR TITLE
Fix ResStock inverse weight

### DIFF
--- a/buildstockbatch/workflow_generator/residential.py
+++ b/buildstockbatch/workflow_generator/residential.py
@@ -253,7 +253,7 @@ class ResidentialDefaultWorkflowGenerator(WorkflowGeneratorBase):
         bld_exist_model_args = {
             'building_id': building_id,
             'workflow_json': 'measure-info.json',
-            'sample_weight': self.n_datapoints / self.cfg['baseline']['n_buildings_represented'],
+            'sample_weight': self.cfg['baseline']['n_buildings_represented'] / self.n_datapoints,
         }
         if 'measures_to_ignore' in workflow_args:
             bld_exist_model_args['measures_to_ignore'] = '|'.join(workflow_args['measures_to_ignore'])

--- a/buildstockbatch/workflow_generator/test_workflow_generator.py
+++ b/buildstockbatch/workflow_generator/test_workflow_generator.py
@@ -1,6 +1,7 @@
 from buildstockbatch.workflow_generator.base import WorkflowGeneratorBase
 from buildstockbatch.workflow_generator.residential import ResidentialDefaultWorkflowGenerator
 from buildstockbatch.workflow_generator.commercial import CommercialDefaultWorkflowGenerator
+import pytest
 
 
 def test_apply_logic_recursion():
@@ -119,6 +120,25 @@ def test_residential_simulation_controls_config(mocker):
     assert(args['begin_month'] == 7)
     for argname in ('begin_day_of_month', 'end_month', 'end_day_of_month', 'calendar_year'):
         assert(args[argname] == default_args[argname])
+
+
+def test_residential_simulation_weight(mocker):
+    cfg = {
+        'baseline': {
+            'n_buildings_represented': 1000
+        },
+        'workflow_generator': {
+            'type': 'residential_default',
+            'args': {}
+        }
+    }
+    n_datapoints = 10
+    sim_id = 'bldb1up1'
+    building_id = 1
+    upgrade_idx = None
+    osw_gen = ResidentialDefaultWorkflowGenerator(cfg, n_datapoints)
+    osw = osw_gen.create_osw(sim_id, building_id, upgrade_idx)
+    assert(osw['steps'][1]['arguments']['sample_weight'] == pytest.approx(100, abs=1e-6))
 
 
 def test_timeseries_csv_export(mocker):

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -24,3 +24,11 @@ Development Changelog
         of dask was incompatible with the latest version of dask. We temporarily
         pinned the sublibrary so that new installs would work. They have fixed
         that problem now, so this removes the restriction on that library. 
+
+    .. change::
+        :tags: bugfix
+        :pullreq: 234
+        :tickets:
+
+        For ResStock the ``build_existing_model.sample_weight`` was inverse to what we would expect. The bug was 
+        identified in the residential workflow generator.


### PR DESCRIPTION
Fixes #234.

## Pull Request Description

This pull request fixes the issue that the ResStock weight is inverse to what it is supposed to be. The issue was identified in the workflow generator.

I tested the result locally with `buildstock_docker`. 

I would suggest this change be included in a 0.20.1 release as it breaks the residential validation workflows.

## Checklist

Not all may apply

- [x] Code changes (must work)
- [x] Tests exercising your feature/bug fix (check coverage report on CircleCI build -> Artifacts)
- [x] All other unit tests passing
- [x] ~~Update validation for project config yaml file changes~~
- [x] ~~Update existing documentation~~
- [x] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
- [x] Add to the changelog_dev.rst file and propose migration text in the pull request
