### PR TITLE
Trim the buildstock.csv for each batch

### DIFF
--- a/buildstockbatch/test/test_eagle.py
+++ b/buildstockbatch/test/test_eagle.py
@@ -201,6 +201,12 @@ def test_run_building_process(mocker,  basic_residential_project_file):
     with open(results_dir / 'job001.json', 'w') as f:
         json.dump(job_json, f)
 
+    sample_buildstock_csv = pd.DataFrame.from_records([{'Building': i, 'Dummy Column': i*i} for i in range(10)])
+    os.makedirs(results_dir / 'housing_characteristics', exist_ok=True)
+    os.makedirs(results_dir / 'local_housing_characteristics', exist_ok=True)
+    os.makedirs(results_dir / 'weather', exist_ok=True)
+    sample_buildstock_csv.to_csv(results_dir / 'housing_characteristics' / 'buildstock.csv', index=False)
+
     def sequential_parallel(**kwargs):
         kw2 = kwargs.copy()
         kw2['n_jobs'] = 1
@@ -210,10 +216,9 @@ def test_run_building_process(mocker,  basic_residential_project_file):
     mocker.patch('buildstockbatch.eagle.Parallel', sequential_parallel)
     mocker.patch('buildstockbatch.eagle.subprocess')
 
-    mocker.patch.object(EagleBatch, 'weather_dir', None)
     mocker.patch.object(EagleBatch, 'singularity_image', '/path/to/singularity.simg')
-    mocker.patch.object(EagleBatch, 'clear_and_copy_dir')
     mocker.patch.object(EagleBatch, 'local_output_dir', results_dir)
+    mocker.patch.object(EagleBatch, 'local_housing_characteristics_dir', results_dir / 'local_housing_characteristics')
     mocker.patch.object(EagleBatch, 'results_dir', results_dir)
 
     def make_sim_dir_mock(building_id, upgrade_idx, base_dir, overwrite_existing=False):
@@ -257,6 +262,12 @@ def test_run_building_process(mocker,  basic_residential_project_file):
         results_file = results_dir / 'results' / 'simulation_output' / 'timeseries' / file.parent.name / file.name
         compare_ts_parquets(file, results_file)
 
+    # Check that buildstock.csv was trimmed properly
+    local_buildstock_df = pd.read_csv(results_dir / 'local_housing_characteristics' / 'buildstock.csv')
+    unique_buildings = {x[0] for x in job_json['batch']}
+    assert len(unique_buildings) == len(local_buildstock_df)
+    assert unique_buildings == set(local_buildstock_df['Building'])
+
 
 def test_run_building_error_caught(mocker, basic_residential_project_file):
 
@@ -271,6 +282,12 @@ def test_run_building_error_caught(mocker, basic_residential_project_file):
     with open(results_dir / 'job001.json', 'w') as f:
         json.dump(job_json, f)
 
+    sample_buildstock_csv = pd.DataFrame.from_records([{'Building': i, 'Dummy Column': i * i} for i in range(10)])
+    os.makedirs(results_dir / 'housing_characteristics', exist_ok=True)
+    os.makedirs(results_dir / 'local_housing_characteristics', exist_ok=True)
+    os.makedirs(results_dir / 'weather', exist_ok=True)
+    sample_buildstock_csv.to_csv(results_dir / 'housing_characteristics' / 'buildstock.csv', index=False)
+
     def raise_error(*args, **kwargs):
         raise RuntimeError('A problem happened')
 
@@ -283,9 +300,7 @@ def test_run_building_error_caught(mocker, basic_residential_project_file):
     mocker.patch('buildstockbatch.eagle.Parallel', sequential_parallel)
     mocker.patch('buildstockbatch.eagle.subprocess')
 
-    mocker.patch.object(EagleBatch, 'weather_dir', None)
     mocker.patch.object(EagleBatch, 'singularity_image', '/path/to/singularity.simg')
-    mocker.patch.object(EagleBatch, 'clear_and_copy_dir')
     mocker.patch.object(EagleBatch, 'run_building', raise_error)
     mocker.patch.object(EagleBatch, 'local_output_dir', results_dir)
     mocker.patch.object(EagleBatch, 'results_dir', results_dir)

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -41,3 +41,11 @@ Development Changelog
         For ResStock the OpenStudio version has changed to v3.2.1. Also, the residential workflow generator has changed
         slightly. Simulation output files retention and deletion can be controlled through arguments to the
         ServerDirectoryCleanup measure.
+
+    .. change::
+        :tags: general, feature, eagle
+        :pullreq: 246
+        :tickets:
+
+        The buildstock.csv is trimmed for each batch job to hold only the rows corresponding to buildings in the batch.
+        This improves speed and memory consumption when the file is loaded in ResStock.


### PR DESCRIPTION
Makes simulation faster by reducing the size of buildstock.csv file.

## Pull Request Description
Trims the buildstock.csv to include only rows for the current batch. Reduces the number of rows that need to be scanned by ResStock to find the entry for a given building.

Companion PR in ResStock: https://github.com/NREL/resstock/pull/701
Corresponding fix for BSB AWS is here: https://github.com/NREL/buildstockbatch/pull/245/files

## Checklist

Not all may apply

- [x] Code changes (must work)
- [x] Tests exercising your feature/bug fix (check coverage report on CircleCI build -> Artifacts)
- [x] All other unit tests passing
- [x] ~~Update validation for project config yaml file changes~~
- [x] ~~Update existing documentation~~
- [x] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
- [x] Add to the changelog_dev.rst file and propose migration text in the pull request
