### PR TITLE
Smaller timeseries partitions

### DIFF
--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -34,7 +34,7 @@ import time
 
 logger = logging.getLogger(__name__)
 
-MAX_PARQUET_MEMORY = 4000  # maximum size (MB) of the parquet file in memory when combining multiple parquets
+MAX_PARQUET_MEMORY = 1000  # maximum size (MB) of the parquet file in memory when combining multiple parquets
 
 
 def read_data_point_out_json(fs, reporting_measures, filename):

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -49,3 +49,12 @@ Development Changelog
 
         The buildstock.csv is trimmed for each batch job to hold only the rows corresponding to buildings in the batch.
         This improves speed and memory consumption when the file is loaded in ResStock.
+
+    .. change:
+        :tags: general, postprocessing
+        :pullreq: 247
+
+        The output partition size of 4GB was making downstream data processing
+        difficult. Both spark and dask clusters were failing due to out of
+        memory errors. I'm changing it back to 1GB, which will make more files,
+        but each will be more manageable.


### PR DESCRIPTION
## Pull Request Description

The output partition size of 4GB was making downstream data processing difficult. Both spark and dask clusters were failing due to out of memory errors. I'm changing it back to 1GB, which will make more files, but each will be more manageable.

## Checklist

Not all may apply

- [x] Code changes (must work)
- [ ] Tests exercising your feature/bug fix (check coverage report on CircleCI build -> Artifacts)
- [ ] All other unit tests passing
- [x] ~~Update validation for project config yaml file changes~~
- [x] ~~ Update existing documentation~~
- [ ] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
- [x] Add to the changelog_dev.rst file and propose migration text in the pull request
