### PR TITLE
ensure all_ts_cols is always a set

### DIFF
--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -201,7 +201,7 @@ def clean_up_results_df(df, cfg, keep_upgrade_id=False):
 def get_cols(fs, filename):
     with fs.open(filename, 'rb') as f:
         schema = parquet.read_schema(f)
-    return schema.names
+    return set(schema.names)
 
 
 def read_results_json(fs, filename):
@@ -271,7 +271,7 @@ def combine_results(fs, results_dir, cfg, do_timeseries=True):
         logger.info("Collecting all the columns in timeseries parquet files.")
         ts_filenames = fs.glob(f'{ts_in_dir}/up*/bldg*.parquet')
         all_ts_cols = db.from_sequence(ts_filenames, partition_size=100).map(partial(get_cols, fs)).\
-            fold(lambda x, y: set(x).union(y)).compute()
+            fold(lambda x, y: x.union(y)).compute()
 
         # Sort the columns
         all_ts_cols_sorted = ['building_id'] + sorted(x for x in all_ts_cols if x.startswith('time'))

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -65,3 +65,17 @@ Development Changelog
         :tickets:
 
         For ResStock the OpenStudio version has changed to v3.3.0.
+
+    .. change::
+        :tags: bugfix
+        :pullreq: 258, 262
+        :tickets: 253
+
+        Fixes an issue that caused out of memory error when postprocessing large run with many upgrades.
+
+    .. change::
+        :tags: bugfix
+        :pullreq: 263
+        :tickets: 261
+
+        Fixes a bug that caused postprocessing to crash when there is only one datapoint.


### PR DESCRIPTION
Fixes #261  .

## Pull Request Description

When there is only one datapoint, the fold doesn't work and all_ts_cols remains a list which causes crash in subsequent statements. This fixes the issue by ensuring all_ts_cols is always a set.

## Checklist

Not all may apply

- [x] Code changes (must work)
- [x] Tests exercising your feature/bug fix (check coverage report on CircleCI build -> Artifacts)
- [x] All other unit tests passing
- [ ] Update validation for project config yaml file changes
- [ ] Update existing documentation
- [x] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
- [x] Add to the changelog_dev.rst file and propose migration text in the pull request
