### PR TITLE
Suppress metadata matching between different results_job*.json

### DIFF
--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -262,7 +262,7 @@ def combine_results(fs, results_dir, cfg, do_timeseries=True):
     results_json_files = fs.glob(f'{sim_output_dir}/results_job*.json.gz')
     if results_json_files:
         delayed_results_dfs = [dask.delayed(read_results_json)(fs, x) for x in results_json_files]
-        results_df = dd.from_delayed(delayed_results_dfs)
+        results_df = dd.from_delayed(delayed_results_dfs,  verify_meta=False)
     else:
         raise ValueError("No simulation results found to post-process.")
 

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -50,7 +50,7 @@ Development Changelog
         The buildstock.csv is trimmed for each batch job to hold only the rows corresponding to buildings in the batch.
         This improves speed and memory consumption when the file is loaded in ResStock.
 
-    .. change:
+    .. change::
         :tags: general, postprocessing
         :pullreq: 247
 
@@ -79,3 +79,10 @@ Development Changelog
         :tickets: 261
 
         Fixes a bug that caused postprocessing to crash when there is only one datapoint.
+
+    .. change::
+        :tags: bugfix
+        :pullreq: 266
+        :tickets: 265
+
+        Fixes a bug that caused postprocessing to crash on small runs where some jobs have failed sims.


### PR DESCRIPTION
Fixes #265.

## Pull Request Description

Different results_jobX.json files can have different datatype for the same column. 
This happens when some results_jobX.json have failed simulation and the datetypes in that results_jobX.json is chosen by pandas to support missing values. That means, the dtype for numeric column cannot be int (because int datatype cannot support missing value) and it will be downcast to something like float or object.  But other results_jobX.json may not have any failed simulation, so the datatype can be more specific like int64. This results in metadata mismatch error when dask tries to read them those multiple dataframes into single dataframe. This PR 'fixes' the issue by suppressing this metadata verification between different dataframes returned by the delayed objects. The default behavior when meta verification is disabled is that (empirically tested) the final datatype is chosen such that it can represent the values in both of the dataframes. This behavior seems consistent with the existing behavior where we loaded everything into a single pandas dataframe. 

## Checklist

Not all may apply

- [x] Code changes (must work)
- [ ] Tests exercising your feature/bug fix (check coverage report on CircleCI build -> Artifacts)
- [x] All other unit tests passing
- [x] ~~Update validation for project config yaml file changes~~
- [x] ~~Update existing documentation~~
- [x] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
- [x] Add to the changelog_dev.rst file and propose migration text in the pull request
