### PR TITLE
Enable partitioning

### DIFF
--- a/buildstockbatch/base.py
+++ b/buildstockbatch/base.py
@@ -291,7 +291,7 @@ class BuildStockBatchBase(object):
     def validate_postprocessing_spec(project_file):
         cfg = get_project_configuration(project_file)  # noqa F841
         param_option_dict, _ = BuildStockBatchBase.get_param_option_dict(project_file)
-        partition_cols = cfg.get('postprocessing',{}).get("partition_columns",[])
+        partition_cols = cfg.get('postprocessing', {}).get("partition_columns", [])
         invalid_cols = [c for c in partition_cols if c not in param_option_dict.keys()]
         if invalid_cols:
             raise ValidationError(f"The following partition columns are not valid: {invalid_cols}")
@@ -435,7 +435,7 @@ class BuildStockBatchBase(object):
                     source_str_package = source_str_upgrade + ", in package_apply_logic"
                     source_option_str_list += get_all_option_str(source_str_package, upgrade['package_apply_logic'])
 
-        if 'downselect' in cfg or "downselect" in cfg.get('sampler',{}).get('type'):
+        if 'downselect' in cfg or "downselect" in cfg.get('sampler', {}).get('type'):
             source_str = "In downselect"
             logic = cfg['downselect']['logic'] if 'downselect' in cfg else cfg['sampler']['args']['logic']
             source_option_str_list += get_all_option_str(source_str, logic)

--- a/buildstockbatch/base.py
+++ b/buildstockbatch/base.py
@@ -180,14 +180,14 @@ class BuildStockBatchBase(object):
         # Convert the timeseries data to parquet
         # and copy it to the results directory
         timeseries_filepath = os.path.join(sim_dir, 'run', 'results_timeseries.csv')
-        skiprows = [1]
         # FIXME: Allowing both names here for compatibility. Should consolidate on one timeseries filename.
-        if not os.path.isfile(timeseries_filepath):
-            timeseries_filepath = os.path.join(sim_dir, 'run', 'enduse_timeseries.csv')
-            skiprows = []
-            units_dict = {}
-        else:
+        if os.path.isfile(timeseries_filepath):
             units_dict = pd.read_csv(timeseries_filepath, nrows=1).transpose().to_dict()[0]
+            skiprows = [1]
+        else:
+            timeseries_filepath = os.path.join(sim_dir, 'run', 'enduse_timeseries.csv')
+            units_dict = {}
+            skiprows = []
 
         schedules_filepath = ''
         if os.path.isdir(os.path.join(sim_dir, 'generated_files')):
@@ -216,8 +216,8 @@ class BuildStockBatchBase(object):
                 Will rename column names like End Use: Natural Gas: Range/Oven to
                 end_use__natural_gas__range_oven__kbtu to play nice with Athena
                 """
-                unit = units_dict.get(x)
-                unit = '' if not isinstance(unit, str) else unit
+                unit = units_dict.get(x)  # missing units (e.g. for time) gets nan
+                unit = unit if isinstance(unit, str) else ''  
                 sepecial_characters = [':', ' ', '/']
                 for char in sepecial_characters:
                     x = x.replace(char, '_')

--- a/buildstockbatch/base.py
+++ b/buildstockbatch/base.py
@@ -255,7 +255,7 @@ class BuildStockBatchBase(object):
         assert(BuildStockBatchBase.validate_reference_scenario(project_file))
         assert(BuildStockBatchBase.validate_options_lookup(project_file))
         assert(BuildStockBatchBase.validate_measure_references(project_file))
-        assert(BuildStockBatchBase.validate_options_lookup(project_file))
+        assert(BuildStockBatchBase.validate_postprocessing_spec(project_file))
         logger.info('Base Validation Successful')
         return True
 

--- a/buildstockbatch/base.py
+++ b/buildstockbatch/base.py
@@ -217,7 +217,7 @@ class BuildStockBatchBase(object):
                 end_use__natural_gas__range_oven__kbtu to play nice with Athena
                 """
                 unit = units_dict.get(x)  # missing units (e.g. for time) gets nan
-                unit = unit if isinstance(unit, str) else ''  
+                unit = unit if isinstance(unit, str) else ''
                 sepecial_characters = [':', ' ', '/']
                 for char in sepecial_characters:
                     x = x.replace(char, '_')

--- a/buildstockbatch/base.py
+++ b/buildstockbatch/base.py
@@ -451,6 +451,7 @@ class BuildStockBatchBase(object):
                     source_str_package = source_str_upgrade + ", in package_apply_logic"
                     source_option_str_list += get_all_option_str(source_str_package, upgrade['package_apply_logic'])
 
+        #  TODO: refactor this into Sampler.validate_args
         if 'downselect' in cfg or "downselect" in cfg.get('sampler', {}).get('type'):
             source_str = "In downselect"
             logic = cfg['downselect']['logic'] if 'downselect' in cfg else cfg['sampler']['args']['logic']

--- a/buildstockbatch/base.py
+++ b/buildstockbatch/base.py
@@ -179,14 +179,16 @@ class BuildStockBatchBase(object):
 
         # Convert the timeseries data to parquet
         # and copy it to the results directory
-        results_timeseries_filepath = os.path.join(sim_dir, 'run', 'results_timeseries.csv')
-        timeseries_filepath = results_timeseries_filepath
+        timeseries_filepath = os.path.join(sim_dir, 'run', 'results_timeseries.csv')
         skiprows = [1]
         # FIXME: Allowing both names here for compatibility. Should consolidate on one timeseries filename.
-        if not os.path.isfile(results_timeseries_filepath):
-            enduse_timeseries_filepath = os.path.join(sim_dir, 'run', 'enduse_timeseries.csv')
-            timeseries_filepath = enduse_timeseries_filepath
-            skiprows = False
+        if not os.path.isfile(timeseries_filepath):
+            timeseries_filepath = os.path.join(sim_dir, 'run', 'enduse_timeseries.csv')
+            skiprows = []
+            units_dict = None
+        else:
+            units_dict = pd.read_csv("results_timeseries.csv", nrows=1, header=[0]).transpose().to_dict()[0]
+
         schedules_filepath = ''
         if os.path.isdir(os.path.join(sim_dir, 'generated_files')):
             for file in os.listdir(os.path.join(sim_dir, 'generated_files')):
@@ -200,10 +202,8 @@ class BuildStockBatchBase(object):
             if not actual_time_cols:
                 logger.error(f'Did not find any time column ({possible_time_cols}) in {timeseries_filepath}.')
                 raise RuntimeError(f'Did not find any time column ({possible_time_cols}) in {timeseries_filepath}.')
-            if skiprows:
-                tsdf = pd.read_csv(timeseries_filepath, parse_dates=actual_time_cols, skiprows=skiprows)
-            else:
-                tsdf = pd.read_csv(timeseries_filepath, parse_dates=actual_time_cols)
+            
+            tsdf = pd.read_csv(timeseries_filepath, parse_dates=actual_time_cols, skiprows=skiprows)
             if os.path.isfile(schedules_filepath):
                 schedules = pd.read_csv(schedules_filepath)
                 schedules.rename(columns=lambda x: f'schedules_{x}', inplace=True)

--- a/buildstockbatch/base.py
+++ b/buildstockbatch/base.py
@@ -187,7 +187,7 @@ class BuildStockBatchBase(object):
             skiprows = []
             units_dict = {}
         else:
-            units_dict = pd.read_csv("results_timeseries.csv", nrows=1).transpose().to_dict()[0]
+            units_dict = pd.read_csv(timeseries_filepath, nrows=1).transpose().to_dict()[0]
 
         schedules_filepath = ''
         if os.path.isdir(os.path.join(sim_dir, 'generated_files')):

--- a/buildstockbatch/eagle.py
+++ b/buildstockbatch/eagle.py
@@ -480,11 +480,10 @@ class EagleBatch(BuildStockBatchBase):
         memory = self.cfg['eagle'].get('postprocessing', {}).get('node_memory_mb', 85248)
         n_procs = self.cfg['eagle'].get('postprocessing', {}).get('n_procs', 16)
         n_workers = self.cfg['eagle'].get('postprocessing', {}).get('n_workers', 2)
-        upgrades_list = self.cfg.get('postprocessing', {}).get('upgrades', [])
         print(f"Submitting job to {n_workers} {memory}MB memory nodes using {n_procs} cores in each.")
         # Throw an error if the files already exist.
 
-        if not upload_only and not upgrades_list:  # TODO validate that the folders in upgrades_list don't exist
+        if not upload_only:
             for subdir in ('parquet', 'results_csvs'):
                 subdirpath = pathlib.Path(self.output_dir, 'results', subdir)
                 if subdirpath.exists():

--- a/buildstockbatch/eagle.py
+++ b/buildstockbatch/eagle.py
@@ -478,7 +478,7 @@ class EagleBatch(BuildStockBatchBase):
         account = self.cfg['eagle']['account']
         walltime = self.cfg['eagle'].get('postprocessing', {}).get('time', '1:30:00')
         memory = self.cfg['eagle'].get('postprocessing', {}).get('node_memory_mb', 85248)
-        n_procs = self.cfg['eagle'].get('postprocessing', {}).get('n_procs', 5)
+        n_procs = self.cfg['eagle'].get('postprocessing', {}).get('n_procs', 16)
         n_workers = self.cfg['eagle'].get('postprocessing', {}).get('n_workers', 2)
         upgrades_list = self.cfg.get('postprocessing', {}).get('upgrades', [])
         print(f"Submitting job to {n_workers} {memory}MB memory nodes using {n_procs} cores in each.")

--- a/buildstockbatch/eagle.py
+++ b/buildstockbatch/eagle.py
@@ -478,7 +478,8 @@ class EagleBatch(BuildStockBatchBase):
         account = self.cfg['eagle']['account']
         walltime = self.cfg['eagle'].get('postprocessing', {}).get('time', '1:30:00')
         memory = self.cfg['eagle'].get('postprocessing', {}).get('node_memory_mb', 85248)
-        print(f"Submitting job to {memory}MB memory nodes.")
+        n_procs = self.cfg['eagle'].get('postprocessing', {}).get('n_procs', 5)
+        print(f"Submitting job to {memory}MB memory nodes using {n_procs} cores in each.")
         # Throw an error if the files already exist.
         if not upload_only:
             for subdir in ('parquet', 'results_csvs'):
@@ -503,6 +504,7 @@ class EagleBatch(BuildStockBatchBase):
         env['OUT_DIR'] = self.output_dir
         env['UPLOADONLY'] = str(upload_only)
         env['MEMORY'] = str(memory)
+        env['NPROCS'] = str(n_procs)
         here = os.path.dirname(os.path.abspath(__file__))
         eagle_post_sh = os.path.join(here, 'eagle_postprocessing.sh')
 
@@ -510,7 +512,7 @@ class EagleBatch(BuildStockBatchBase):
             'sbatch',
             '--account={}'.format(account),
             '--time={}'.format(walltime),
-            '--export=PROJECTFILE,MY_CONDA_ENV,OUT_DIR,UPLOADONLY,MEMORY',
+            '--export=PROJECTFILE,MY_CONDA_ENV,OUT_DIR,UPLOADONLY,MEMORY,NPROCS',
             '--job-name=bstkpost',
             '--output=postprocessing.out',
             '--nodes=1',

--- a/buildstockbatch/eagle.py
+++ b/buildstockbatch/eagle.py
@@ -480,9 +480,11 @@ class EagleBatch(BuildStockBatchBase):
         memory = self.cfg['eagle'].get('postprocessing', {}).get('node_memory_mb', 85248)
         n_procs = self.cfg['eagle'].get('postprocessing', {}).get('n_procs', 5)
         n_workers = self.cfg['eagle'].get('postprocessing', {}).get('n_workers', 2)
+        upgrades_list = self.cfg.get('postprocessing',{}).get('upgrades', [])
         print(f"Submitting job to {n_workers} {memory}MB memory nodes using {n_procs} cores in each.")
         # Throw an error if the files already exist.
-        if not upload_only:
+
+        if not upload_only and not upgrades_list:  # TODO validate that the folders in upgrades_list don't exist
             for subdir in ('parquet', 'results_csvs'):
                 subdirpath = pathlib.Path(self.output_dir, 'results', subdir)
                 if subdirpath.exists():

--- a/buildstockbatch/eagle.py
+++ b/buildstockbatch/eagle.py
@@ -479,7 +479,8 @@ class EagleBatch(BuildStockBatchBase):
         walltime = self.cfg['eagle'].get('postprocessing', {}).get('time', '1:30:00')
         memory = self.cfg['eagle'].get('postprocessing', {}).get('node_memory_mb', 85248)
         n_procs = self.cfg['eagle'].get('postprocessing', {}).get('n_procs', 5)
-        print(f"Submitting job to {memory}MB memory nodes using {n_procs} cores in each.")
+        n_workers = self.cfg['eagle'].get('postprocessing', {}).get('n_workers', 2)
+        print(f"Submitting job to {n_workers} {memory}MB memory nodes using {n_procs} cores in each.")
         # Throw an error if the files already exist.
         if not upload_only:
             for subdir in ('parquet', 'results_csvs'):
@@ -519,7 +520,7 @@ class EagleBatch(BuildStockBatchBase):
             ':',
             '--mem={}'.format(memory),
             '--output=dask_workers.out',
-            '--nodes={}'.format(self.cfg['eagle'].get('postprocessing', {}).get('n_workers', 2)),
+            '--nodes={}'.format(n_workers),
             eagle_post_sh
         ]
 

--- a/buildstockbatch/eagle.py
+++ b/buildstockbatch/eagle.py
@@ -480,7 +480,7 @@ class EagleBatch(BuildStockBatchBase):
         memory = self.cfg['eagle'].get('postprocessing', {}).get('node_memory_mb', 85248)
         n_procs = self.cfg['eagle'].get('postprocessing', {}).get('n_procs', 5)
         n_workers = self.cfg['eagle'].get('postprocessing', {}).get('n_workers', 2)
-        upgrades_list = self.cfg.get('postprocessing',{}).get('upgrades', [])
+        upgrades_list = self.cfg.get('postprocessing', {}).get('upgrades', [])
         print(f"Submitting job to {n_workers} {memory}MB memory nodes using {n_procs} cores in each.")
         # Throw an error if the files already exist.
 

--- a/buildstockbatch/eagle.py
+++ b/buildstockbatch/eagle.py
@@ -478,7 +478,7 @@ class EagleBatch(BuildStockBatchBase):
         account = self.cfg['eagle']['account']
         walltime = self.cfg['eagle'].get('postprocessing', {}).get('time', '1:30:00')
         memory = self.cfg['eagle'].get('postprocessing', {}).get('node_memory_mb', 85248)
-        n_procs = self.cfg['eagle'].get('postprocessing', {}).get('n_procs', 16)
+        n_procs = self.cfg['eagle'].get('postprocessing', {}).get('n_procs', 18)
         n_workers = self.cfg['eagle'].get('postprocessing', {}).get('n_workers', 2)
         print(f"Submitting job to {n_workers} {memory}MB memory nodes using {n_procs} cores in each.")
         # Throw an error if the files already exist.

--- a/buildstockbatch/eagle_postprocessing.sh
+++ b/buildstockbatch/eagle_postprocessing.sh
@@ -11,6 +11,7 @@ export POSTPROCESS=1
 
 echo "UPLOADONLY: ${UPLOADONLY}"
 echo "MEMORY: ${MEMORY}"
+echo "NPROCS: ${NPROCS}"
 
 SCHEDULER_FILE=$OUT_DIR/dask_scheduler.json
 
@@ -22,6 +23,6 @@ echo $SLURM_JOB_NODELIST_PACK_GROUP_1
 pdsh -w $SLURM_JOB_NODELIST_PACK_GROUP_1 "free -h"
 
 $MY_CONDA_ENV/bin/dask-scheduler --scheduler-file $SCHEDULER_FILE &> $OUT_DIR/dask_scheduler.out &
-pdsh -w $SLURM_JOB_NODELIST_PACK_GROUP_1 "$MY_CONDA_ENV/bin/dask-worker --scheduler-file $SCHEDULER_FILE --local-directory /tmp/scratch/dask --nprocs 1 --nthreads 1 --memory-limit ${MEMORY}MB" &> $OUT_DIR/dask_workers.out &
+pdsh -w $SLURM_JOB_NODELIST_PACK_GROUP_1 "$MY_CONDA_ENV/bin/dask-worker --scheduler-file $SCHEDULER_FILE --local-directory /tmp/scratch/dask --nprocs ${NPROCS} --nthreads 1 --memory-limit ${MEMORY}MB" &> $OUT_DIR/dask_workers.out &
 
 time python -u -m buildstockbatch.eagle "$PROJECTFILE"

--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -388,6 +388,7 @@ def get_upgrade_list(cfg):
     upgrade_list = [upgrade for upgrade in upgrade_list if upgrade in full_upgrade_list]
     return upgrade_list
 
+
 def write_metadata_files(fs, parquet_root_dir, partition_columns):
     df = dd.read_parquet(parquet_root_dir)
     sch = pa.Schema.from_pandas(df._meta_nonempty)
@@ -400,6 +401,7 @@ def write_metadata_files(fs, parquet_root_dir, partition_columns):
     logger.info(f"Gathered {len(concat_files)} files. Now writing _metadata")
     create_metadata_file(concat_files, root_dir=parquet_root_dir, engine='pyarrow', fs=fs)
     logger.info(f"_metadata file written to {parquet_root_dir}")
+
 
 def combine_results(fs, results_dir, cfg, do_timeseries=True):
     """Combine the results of the batch simulations.
@@ -452,9 +454,9 @@ def combine_results(fs, results_dir, cfg, do_timeseries=True):
             if ts_filenames:
                 do_timeseries = True
                 logger.info(f"Found {len(ts_filenames)} files for upgrade {Path(upgrade_folder).name}.")
-                files_bag =  db.from_sequence(ts_filenames, partition_size=100)
+                files_bag = db.from_sequence(ts_filenames, partition_size=100)
                 all_ts_cols |= files_bag.map(partial(get_cols, fs, upgrade_folder)).\
-                               fold(lambda x, y: x.union(y)).compute()
+                    fold(lambda x, y: x.union(y)).compute()
                 logger.info("Collected all the columns")
             else:
                 logger.warning(f"There are no timeseries files for upgrade {Path(upgrade_folder).name}.")
@@ -469,7 +471,7 @@ def combine_results(fs, results_dir, cfg, do_timeseries=True):
         logger.info(f"Got {len(all_ts_cols_sorted)} columns in total")
         logger.info(f"The columns are: {all_ts_cols_sorted}")
     else:
-        logger.warning(f"There are no timeseries files for any upgrades.")
+        logger.warning("There are no timeseries files for any upgrades.")
 
     results_df_groups = results_df.groupby('upgrade')
     upgrade_list = get_upgrade_list(cfg)
@@ -591,7 +593,7 @@ def combine_results(fs, results_dir, cfg, do_timeseries=True):
             with tempfile.TemporaryDirectory() as tmpdir:
                 tmpfilepath = Path(tmpdir, 'dask-report.html')
                 with performance_report(filename=str(tmpfilepath)):
-                    dask.compute(map(concat_partial, *zip(*enumerate(bldg_id_groups)), partition_vals_list ))
+                    dask.compute(map(concat_partial, *zip(*enumerate(bldg_id_groups)), partition_vals_list))
                 if tmpfilepath.exists():
                     fs.put_file(str(tmpfilepath), f'{results_dir}/dask_combine_report{upgrade_id}.html')
 

--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -419,7 +419,7 @@ def combine_results(fs, results_dir, cfg, do_timeseries=True):
 
     # create the postprocessing results directories
     for dr in dirs:
-        fs.makedirs(dr, exist_ok=True)
+        fs.makedirs(dr)
 
     # Results "CSV"
     results_json_files = fs.glob(f'{sim_output_dir}/results_job*.json.gz')

--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -268,7 +268,7 @@ def read_enduse_timeseries_parquet(fs, all_cols, filename):
 
 def concat_and_normalize(fs, all_cols, src_path, dst_path, partition_columns, indx, bldg_ids, partition_vals):
     dfs = []
-    for bldg_id in bldg_ids:
+    for bldg_id in sorted(bldg_ids):
         src_filename = Path(src_path) / f"bldg{bldg_id:07}.parquet"
         df = pd.read_parquet(src_filename, engine='pyarrow')
         for col in set(all_cols).difference(df.columns.values):
@@ -459,7 +459,7 @@ def combine_results(fs, results_dir, cfg, do_timeseries=True):
                     fold(lambda x, y: x.union(y)).compute()
                 logger.info("Collected all the columns")
             else:
-                logger.warning(f"There are no timeseries files for upgrade {Path(upgrade_folder).name}.")
+                logger.info(f"There are no timeseries files for upgrade {Path(upgrade_folder).name}.")
 
     if do_timeseries:
         # Sort the columns

--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -401,7 +401,7 @@ def combine_results(fs, results_dir, cfg, do_timeseries=True):
 
     # create the postprocessing results directories
     for dr in dirs:
-        fs.makedirs(dr,exist_ok=True)
+        fs.makedirs(dr, exist_ok=True)
 
     # Results "CSV"
     results_json_files = fs.glob(f'{sim_output_dir}/results_job*.json.gz')

--- a/buildstockbatch/schemas/v0.3.yaml
+++ b/buildstockbatch/schemas/v0.3.yaml
@@ -47,6 +47,7 @@ hpc-postprocessing-spec:
   time: int(required=True)
   n_workers: int(required=False)
   node_memory_mb: enum(85248, 180224, 751616, required=False)
+  n_procs: enum(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, required=False)
   parquet_memory_mb: int(required=False)
 
 sampler-spec:

--- a/buildstockbatch/schemas/v0.3.yaml
+++ b/buildstockbatch/schemas/v0.3.yaml
@@ -45,10 +45,10 @@ hpc-spec:
 
 hpc-postprocessing-spec:
   time: int(required=True)
-  n_workers: int(required=False)
+  n_workers: int(min=1, max=32, required=False)
   node_memory_mb: enum(85248, 180224, 751616, required=False)
-  n_procs: int(min=1, max=32, required=False)
-  parquet_memory_mb: int(required=False)
+  n_procs: int(min=1, max=36, required=False)
+  parquet_memory_mb: int(min=100, max=4096, required=False)
 
 
 sampler-spec:

--- a/buildstockbatch/schemas/v0.3.yaml
+++ b/buildstockbatch/schemas/v0.3.yaml
@@ -47,7 +47,7 @@ hpc-postprocessing-spec:
   time: int(required=True)
   n_workers: int(required=False)
   node_memory_mb: enum(85248, 180224, 751616, required=False)
-  n_procs: enum(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, required=False)
+  n_procs: int(min=1, max=32, required=False)
   parquet_memory_mb: int(required=False)
 
 

--- a/buildstockbatch/schemas/v0.3.yaml
+++ b/buildstockbatch/schemas/v0.3.yaml
@@ -107,7 +107,6 @@ cost-spec:
 
 postprocessing-spec:
   partition_columns: list(str(), required=False)
-  upgrades: list(int, required=False)
   aws: include('aws-postprocessing-spec', required=False)
   keep_individual_timeseries: bool(required=False)
 

--- a/buildstockbatch/schemas/v0.3.yaml
+++ b/buildstockbatch/schemas/v0.3.yaml
@@ -104,6 +104,7 @@ cost-spec:
   multiplier: str(required=True)
 
 postprocessing-spec:
+  partition_columns: list(str(), required=False)
   aws: include('aws-postprocessing-spec', required=False)
   keep_individual_timeseries: bool(required=False)
 

--- a/buildstockbatch/schemas/v0.3.yaml
+++ b/buildstockbatch/schemas/v0.3.yaml
@@ -50,6 +50,7 @@ hpc-postprocessing-spec:
   n_procs: enum(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, required=False)
   parquet_memory_mb: int(required=False)
 
+
 sampler-spec:
   type: str(required=True)
   args: map(key=regex(r'^[a-zA-Z_]\w*$', name='valid variable name'), required=False)
@@ -106,6 +107,7 @@ cost-spec:
 
 postprocessing-spec:
   partition_columns: list(str(), required=False)
+  upgrades: list(int, required=False)
   aws: include('aws-postprocessing-spec', required=False)
   keep_individual_timeseries: bool(required=False)
 

--- a/buildstockbatch/test/test_base.py
+++ b/buildstockbatch/test/test_base.py
@@ -219,13 +219,13 @@ def test_combine_files(basic_residential_project_file):
     test_pq_all = dd.read_parquet(os.path.join(test_path, 'timeseries'), engine='pyarrow')\
         .compute()
 
-    test_pq = test_pq_all[test_pq_all['upgrade']==0].copy().reset_index()
+    test_pq = test_pq_all[test_pq_all['upgrade'] == 0].copy().reset_index()
     reference_pq = dd.read_parquet(os.path.join(reference_path,  'timeseries', 'upgrade=0'), engine='pyarrow')\
         .compute().reset_index()
     reference_pq['upgrade'] = test_pq['upgrade'] = 0
     pd.testing.assert_frame_equal(test_pq, reference_pq)
 
-    test_pq = test_pq_all[test_pq_all['upgrade']==1].copy().reset_index()
+    test_pq = test_pq_all[test_pq_all['upgrade'] == 1].copy().reset_index()
     reference_pq = dd.read_parquet(os.path.join(reference_path,  'timeseries', 'upgrade=1'), engine='pyarrow')\
         .compute().reset_index()
     reference_pq['upgrade'] = test_pq['upgrade'] = 1

--- a/buildstockbatch/test/test_base.py
+++ b/buildstockbatch/test/test_base.py
@@ -323,6 +323,16 @@ def test_upload_files(mocked_boto3, basic_residential_project_file):
     assert (source_file_path, s3_file_path) in files_uploaded
     files_uploaded.remove((source_file_path, s3_file_path))
 
+    s3_file_path = s3_path + 'timeseries/_common_metadata'
+    source_file_path = os.path.join(source_path, 'timeseries', '_common_metadata')
+    assert (source_file_path, s3_file_path) in files_uploaded
+    files_uploaded.remove((source_file_path, s3_file_path))
+
+    s3_file_path = s3_path + 'timeseries/_metadata'
+    source_file_path = os.path.join(source_path, 'timeseries', '_metadata')
+    assert (source_file_path, s3_file_path) in files_uploaded
+    files_uploaded.remove((source_file_path, s3_file_path))
+
     assert len(files_uploaded) == 0, f"These files shouldn't have been uploaded: {files_uploaded}"
 
 

--- a/buildstockbatch/test/test_base.py
+++ b/buildstockbatch/test/test_base.py
@@ -216,16 +216,19 @@ def test_combine_files(basic_residential_project_file):
     pd.testing.assert_frame_equal(test_pq, reference_pq)
 
     # timeseries parquet
-    test_pq = dd.read_parquet(os.path.join(test_path, 'timeseries', 'upgrade=0'), engine='pyarrow')\
-        .compute().reset_index()
+    test_pq_all = dd.read_parquet(os.path.join(test_path, 'timeseries'), engine='pyarrow')\
+        .compute()
+
+    test_pq = test_pq_all[test_pq_all['upgrade']==0].copy().reset_index()
     reference_pq = dd.read_parquet(os.path.join(reference_path,  'timeseries', 'upgrade=0'), engine='pyarrow')\
         .compute().reset_index()
+    reference_pq['upgrade'] = test_pq['upgrade'] = 0
     pd.testing.assert_frame_equal(test_pq, reference_pq)
 
-    test_pq = dd.read_parquet(os.path.join(test_path, 'timeseries', 'upgrade=1'), engine='pyarrow')\
-        .compute().reset_index()
+    test_pq = test_pq_all[test_pq_all['upgrade']==1].copy().reset_index()
     reference_pq = dd.read_parquet(os.path.join(reference_path,  'timeseries', 'upgrade=1'), engine='pyarrow')\
         .compute().reset_index()
+    reference_pq['upgrade'] = test_pq['upgrade'] = 1
     pd.testing.assert_frame_equal(test_pq, reference_pq)
 
 

--- a/buildstockbatch/test/test_eagle.py
+++ b/buildstockbatch/test/test_eagle.py
@@ -256,8 +256,8 @@ def test_run_building_process(mocker,  basic_residential_project_file):
     ts_files = list(refrence_path.glob('**/*.parquet'))
 
     def compare_ts_parquets(source, dst):
-        test_pq = pd.read_parquet(source).reset_index().drop(columns=['index'])
-        reference_pq = pd.read_parquet(dst).reset_index().drop(columns=['index'])
+        test_pq = pd.read_parquet(source).reset_index().drop(columns=['index']).rename(columns=str.lower)
+        reference_pq = pd.read_parquet(dst).reset_index().drop(columns=['index']).rename(columns=str.lower)
         pd.testing.assert_frame_equal(test_pq, reference_pq)
 
     for file in ts_files:

--- a/buildstockbatch/test/test_inputs/enforce-validate-options-bad-2.yml
+++ b/buildstockbatch/test/test_inputs/enforce-validate-options-bad-2.yml
@@ -1,0 +1,59 @@
+schema_version: 0.3
+buildstock_directory: test_openstudio_buildstock_bad
+project_directory: project_singlefamilydetached
+sampler:
+  type: residential_quota_downselect
+  args:
+    n_datapoints: 12345
+    logic: Vintage|2000s
+    resample: False
+baseline:
+  n_buildings_represented: 81221016
+
+upgrades:
+  - upgrade_name: bad upgrade
+    options:
+      - option: Vintage|Extra Argument
+        apply_logic:
+          - or:
+            - Insulation Slab|Invalid Option
+            - Insulation Slab|None
+          - not: Insulation Wall|Good Option||
+          - and:
+              - Vintage|1960s
+              - Vintage| 1980s
+      - option: Insulation Finished Basement|Good Option
+        apply_logic:
+          - Insulation Unfinished Basement|Extra Argument
+    package_apply_logic: Vintage|1970s||Vintage|1941s
+  - options:
+        - option: |
+          apply_logic:
+            - or:
+                - Insulation Slat|Good Option
+                - Insulation Slab|None
+            - not: Insulation Wall|Good Option
+            - and:
+                - Vintage|1960s|Vintage|1960s
+                - Vintage|1980s
+        - option: Insulation Finished Basement|Good Option
+          apply_logic:
+            - Insulation Unfinished Basement|Extra Argument
+    package_apply_logic: Vintage|1960s||Vintage|1940s&&Vintage|1980s
+downselect:
+  logic: Invalid Parameter|2000s
+  resample: False
+
+postprocessing:
+  partition_columns:
+    - bad_partition_column
+    - County
+  aws:
+    region_name: "us-west-2"
+    s3:
+      bucket: some-bucket
+      prefix: some-prefix
+    athena:
+      glue_service_role: service-role/AWSGlueServiceRole-default
+      database_name: buildstock_testing
+      max_crawling_time: 1200

--- a/buildstockbatch/test/test_inputs/enforce-validate-options-good-2.yml
+++ b/buildstockbatch/test/test_inputs/enforce-validate-options-good-2.yml
@@ -1,0 +1,44 @@
+buildstock_directory: test_openstudio_buildstock
+project_directory: project_singlefamilydetached
+schema_version: '0.3'
+weather_files_url: https://fake-url
+sampler:
+  type: residential_quota_downselect
+  args:
+    n_datapoints: 12345
+    logic: Vintage|2000s
+    resample: False
+
+baseline:
+  n_buildings_represented: 81221016
+
+upgrades:
+  - upgrade_name: good upgrade
+    options:
+      - option: Vintage|<1940
+        apply_logic:
+          - or:
+            - Insulation Slab|Good Option
+            - Insulation Slab|None
+          - not: Insulation Wall|Good Option
+          - and:
+              - Vintage|1960s||Vintage|1960s
+              - Vintage|1980s
+      - option: Insulation Finished Basement|Good Option
+        apply_logic:
+          - Insulation Unfinished Basement|Extra Argument
+    package_apply_logic: Vintage|1960s||Vintage|1940s
+
+postprocessing:
+  partition_columns:
+    - State
+    - County
+  aws:
+    region_name: "us-west-2"
+    s3:
+      bucket: some-bucket
+      prefix: some-prefix
+    athena:
+      glue_service_role: service-role/AWSGlueServiceRole-default
+      database_name: buildstock_testing
+      max_crawling_time: 1200

--- a/buildstockbatch/test/test_inputs/test_openstudio_buildstock/resources/options_lookup.tsv
+++ b/buildstockbatch/test/test_inputs/test_openstudio_buildstock/resources/options_lookup.tsv
@@ -12,6 +12,10 @@ Vintage	1980s
 Vintage	1990s															
 Vintage	2000s															
 Vintage	2010s															
+State	VA															
+State	CO															
+County	County1															
+County	County2															
 Insulation Slab	None															
 Insulation Slab	Good Option	ResidentialConstructionsSlab	perimeter_r=0	perimeter_width=0	whole_r=0	gap_r=0	exterior_r=0	exterior_depth=0								
 Insulation Slab	Missing Argument	ResidentialConstructionsSlab	perimeter_r=0	perimeter_width=0	whole_r=10	gap_r=5	exterior_r=0									

--- a/buildstockbatch/test/test_validation.py
+++ b/buildstockbatch/test/test_validation.py
@@ -93,7 +93,8 @@ def test_validation_integration(project_file, expected):
     # patch the validate_options_lookup function to always return true for this case
     with patch.object(BuildStockBatchBase, 'validate_options_lookup', lambda _: True), \
             patch.object(BuildStockBatchBase, 'validate_measure_references', lambda _: True), \
-            patch.object(BuildStockBatchBase, 'validate_workflow_generator', lambda _: True):
+            patch.object(BuildStockBatchBase, 'validate_workflow_generator', lambda _: True), \
+            patch.object(BuildStockBatchBase, 'validate_postprocessing_spec', lambda _: True):
         if expected is not True:
             with pytest.raises(expected):
                 BuildStockBatchBase.validate_project(project_file)

--- a/buildstockbatch/test/test_validation.py
+++ b/buildstockbatch/test/test_validation.py
@@ -171,13 +171,16 @@ def test_bad_path_options_validation(project_file):
 
 @pytest.mark.parametrize("project_file", [
     os.path.join(example_yml_dir, 'enforce-validate-options-good.yml'),
+    os.path.join(example_yml_dir, 'enforce-validate-options-good-2.yml'),
 ])
 def test_good_options_validation(project_file):
     assert BuildStockBatchBase.validate_options_lookup(project_file)
+    assert BuildStockBatchBase.validate_postprocessing_spec(project_file)
 
 
 @pytest.mark.parametrize("project_file", [
     os.path.join(example_yml_dir, 'enforce-validate-options-bad.yml'),
+    os.path.join(example_yml_dir, 'enforce-validate-options-bad-2.yml'),
 ])
 def test_bad_options_validation(project_file):
     try:
@@ -224,3 +227,21 @@ def test_bad_measures_validation(project_file):
     else:
         raise Exception("validate_measure_references was supposed to raise ValueError for "
                         "enforce-validate-measures-bad.yml")
+
+@pytest.mark.parametrize("project_file", [
+    os.path.join(example_yml_dir, 'enforce-validate-measures-good.yml'),
+])
+def test_good_measures_validation(project_file):
+    assert BuildStockBatchBase.validate_measure_references(project_file)
+
+@pytest.mark.parametrize("project_file", [
+    os.path.join(example_yml_dir, 'enforce-validate-options-bad-2.yml'),
+])
+def test_bad_postprocessing_spec_validation(project_file):
+    try:
+        BuildStockBatchBase.validate_postprocessing_spec(project_file)
+    except ValidationError as er:
+        er = str(er)
+        assert "bad_partition_column" in er
+    else:
+        raise Exception("validate_options was supposed to raise ValueError for enforce-validate-options-bad-2.yml")

--- a/buildstockbatch/test/test_validation.py
+++ b/buildstockbatch/test/test_validation.py
@@ -228,11 +228,6 @@ def test_bad_measures_validation(project_file):
         raise Exception("validate_measure_references was supposed to raise ValueError for "
                         "enforce-validate-measures-bad.yml")
 
-@pytest.mark.parametrize("project_file", [
-    os.path.join(example_yml_dir, 'enforce-validate-measures-good.yml'),
-])
-def test_good_measures_validation(project_file):
-    assert BuildStockBatchBase.validate_measure_references(project_file)
 
 @pytest.mark.parametrize("project_file", [
     os.path.join(example_yml_dir, 'enforce-validate-options-bad-2.yml'),

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -36,3 +36,11 @@ Development Changelog
 
         Postprocessing can correctly handle assortment of upgrades with overlaping set of columns with missing and
         non-missing values.
+
+    .. change::
+        :tags: postprocessing, feature
+        :pullreq: 275
+        :tickets:
+
+        Postprocessing can take partition the data before uploading to s3 and Athena. This allows for faster and cheaper
+        queries.

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -42,5 +42,7 @@ Development Changelog
         :pullreq: 275
         :tickets:
 
-        Postprocessing can take partition the data before uploading to s3 and Athena. This allows for faster and cheaper
+        Postprocessing can partition the data before uploading to s3 and Athena. This allows for faster and cheaper
         queries.
+        ``n_procs argument`` is added to ``eagle`` spec to allow users to pick number of CPUs in each node. Default: 18
+        ``partition_columns`` argument is added to ``postprocessing`` spec to allow the partitioning. Default: []

--- a/docs/project_defn.rst
+++ b/docs/project_defn.rst
@@ -144,10 +144,13 @@ the Eagle supercomputer.
 *  ``postprocessing``: Eagle configuration for the postprocessing step
 
     *  ``time``: Maximum time in minutes to allocate postprocessing job
-    *  ``n_workers``: Number of eagle nodes to parallelize the postprocessing job into. Max supported is 32. Default is 2.
+    *  ``n_workers``: Number of eagle nodes to parallelize the postprocessing job into. Max supported is 32.
+                      Default is 2.
+    *  ``n_procs``: Number of CPUs to use within each eagle nodes. Max is 36. Default is 18. Try reducing this if you
+                    get OOM error.
     *  ``node_memory_mb``: The memory (in MB) to request for eagle node for postprocessing. The valid values are
                            85248, 180224 and 751616. Default is 85248.
-    *  ``parquet_memory_mb``: The size (in MB) of the combined parquet file in memory. Default is 40000.
+    *  ``parquet_memory_mb``: The size (in MB) of the combined parquet file in memory. Default is 1000.
 
 .. _aws-config:
 
@@ -258,7 +261,7 @@ The configuration options for postprocessing and AWS upload are:
       Setting this option to ``true`` allows that. Default is ``false``.
 
     * ``partition_columns``: (optional, list) Allows partitioning the output data based on some columns. The columns
-      must match the parameters found in options_lookup.tsv. This allows for efficeint athena queries. Only recommended
+      must match the parameters found in options_lookup.tsv. This allows for efficient athena queries. Only recommended
       for moderate or large sized runs (ndatapoints > 10K)
 
     * ``aws``: (optional) configuration related to uploading to and managing data in amazon web services. For this to

--- a/docs/project_defn.rst
+++ b/docs/project_defn.rst
@@ -253,12 +253,16 @@ The configuration options for postprocessing and AWS upload are:
 
 *  ``postprocessing``: postprocessing configuration
 
-    * ``keep_individual_timeseries``: For some use cases it is useful to keep
+    * ``keep_individual_timeseries``: (optional, bool) For some use cases it is useful to keep
       the timeseries output for each simulation as a separate parquet file.
       Setting this option to ``true`` allows that. Default is ``false``.
 
-    *  ``aws``: configuration related to uploading to and managing data in amazon web services. For this to work, please
-       `configure aws. <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/quickstart.html#configuration>`_
+    * ``partition_columns``: (optional, list) Allows partitioning the output data based on some columns. The columns
+      must match the parameters found in options_lookup.tsv. This allows for efficeint athena queries. Only recommended
+      for moderate or large sized runs (ndatapoints > 10K)
+
+    * ``aws``: (optional) configuration related to uploading to and managing data in amazon web services. For this to
+       work, please `configure aws. <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/quickstart.html#configuration>`_
        Including this key will cause your datasets to be uploaded to AWS, omitting it will cause them not to be uploaded.
 
         *  ``region_name``: The name of the aws region to use for database creation and other services.

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setuptools.setup(
         'pandas>=1.0.0,!=1.0.4',
         'joblib',
         'pyarrow>=3.0.0',
-        'dask[complete]>=2022.2.1',
+        'dask[complete]>=2022.2.0',
         'docker',
         'boto3>=1.10.44',
         's3fs>=0.4.0,<0.5.0',

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setuptools.setup(
         'pandas>=1.0.0,!=1.0.4',
         'joblib',
         'pyarrow>=3.0.0',
-        'dask[complete]>=2021.5',
+        'dask[complete]>=2022.2.1',
         'docker',
         'boto3>=1.10.44',
         's3fs>=0.4.0,<0.5.0',


### PR DESCRIPTION
## Pull Request Description
Adds partitioning capability to buildstockbatch postprocessing. And while doing that:

1.U̶s̶e̶s̶ ̶d̶a̶s̶k̶s̶ ̶'̶t̶o̶_̶p̶a̶r̶q̶u̶e̶t̶'̶ ̶f̶u̶n̶c̶t̶i̶o̶n̶ ̶t̶o̶ ̶w̶r̶i̶t̶e̶ ̶o̶u̶t̶ ̶t̶h̶e̶ ̶p̶a̶r̶q̶u̶e̶t̶ ̶f̶i̶l̶e̶s̶ ̶a̶l̶o̶n̶g̶ ̶w̶i̶t̶h̶ ̶t̶h̶e̶ ̶m̶e̶t̶a̶d̶a̶t̶a̶ ̶f̶i̶l̶e̶s̶.̶ ̶T̶h̶i̶s̶ ̶a̶l̶l̶o̶w̶s̶ ̶f̶o̶r̶ ̶a̶l̶m̶o̶s̶t̶ ̶v̶e̶r̶y̶ ̶f̶a̶s̶t̶ ̶"̶r̶e̶a̶d̶i̶n̶g̶"̶*̶ ̶o̶f̶ ̶t̶h̶e̶ ̶t̶i̶m̶e̶s̶e̶r̶i̶e̶s̶ ̶f̶i̶l̶e̶s̶ ̶b̶a̶c̶k̶ ̶i̶n̶t̶o̶ ̶d̶a̶s̶k̶.̶ ̶(̶*̶ ̶I̶t̶ ̶d̶o̶e̶s̶n̶'̶t̶ ̶r̶e̶a̶l̶l̶y̶ ̶r̶e̶a̶d̶ ̶t̶h̶e̶ ̶w̶h̶o̶l̶e̶ ̶f̶i̶l̶e̶ ̶b̶u̶t̶ ̶i̶t̶ ̶s̶a̶v̶e̶s̶ ̶d̶a̶s̶k̶ ̶f̶r̶o̶m̶ ̶s̶c̶a̶n̶n̶i̶n̶g̶ ̶t̶h̶e̶ ̶f̶i̶l̶e̶ ̶t̶o̶ ̶i̶n̶f̶e̶r̶ ̶n̶u̶m̶b̶e̶r̶ ̶o̶f̶ ̶c̶o̶l̶u̶m̶n̶s̶ ̶a̶n̶d̶ ̶c̶o̶l̶u̶m̶n̶ ̶d̶a̶t̶a̶t̶y̶p̶e̶s̶)̶.̶ Manually writes dask _metadata and _common_metadata files to enable fast reading back of the aggregated dataset.
2.	Adds n_procs argument to eagle postprocessing which defaults to 16. Makes order of magnitude improvement in postprocessing speed. 
3.	Adds more logging in postprocessing workflow. It's a quite a bit more verbose but I think it can be valuable for debugging.

![image](https://user-images.githubusercontent.com/12487392/160745651-dcd059eb-7600-4551-bbca-e79651288ae1.png)

Comparing the postprocessing time between n_procs=1, 5, 10, 20, 36. Also comparing the upload time to s5cmd. There is a slight incentive to try to switch to s5cmd for upload since the upload is really the bottleneck now. And if we do s5cmd on multiple nodes, there is a chance that the upload time can come down further. But, it's not that bad as is either and I am not sure it is worth the trouble. We had used n_procs=1 before because of some OOM scare, but on testing with the latest design, the memory consumption per worker doesn't seem to ever exceed 3GB and I verified up to n_procs=36. The new default of 16 is conservatively chosen to provide ample memory to each worker. 
Check the dask memory distribution below:
![image](https://user-images.githubusercontent.com/12487392/159595376-b66c0221-8f62-4687-bd69-da3f6a50a8e3.png)


I started the task by using a list of delayed objects and creating dask dataframe from that using from_delayed function for doing the aggregation. This worked okay when I was doing hourly run, but it started to choke when I tested on n550K_15min runs. It turns out that creating daskdatafram using from_delayed has its limitation; if we try to do any manipulation of the dataframe at all (which we need to do for aggregation /  joining / writing with partitioning etc), it ends up calling those delayed objects (behind the scene) before it can create the task graph to understand the kind of data the delayed objects would return. I don't fully understand what's going on there, but, it aligns well with what I saw: it takes forever before I see any activity on the dask dashboard, and the memory consumption of the main process where the scheduler sits keeps increasing (eventually crashing the whole thing). This SO question and answer can provide more details and context: https://stackoverflow.com/a/71531717/2105924.  

Anyway, the conclusion from all that is that creating massive dask dataframe out of essentially unformatted raw data is going to lead to problems; we should either preprocess the data to be directly readable with read_parquet or do away with massive dask df. I decided to go with the second option (since if we are going to preprocess, we might as well write the concatenated parquet directly).  One of the reasons we wanted to use dask dataframe was that it allowed us to output _metadata files when writing to parquet. The _metadata files help with super fast reading. Good news is that, I was able to write those _metadata files manually after the aggregation was completed. So, no loss there!


## Checklist

Not all may apply

- [x] Code changes (must work)
- [x] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [ ] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/ci.yml` as necessary.
- [x] All other unit tests passing
- [x] Update validation for project config yaml file changes
- [x] Update existing documentation
- [x] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
- [x] Add to the changelog_dev.rst file and propose migration text in the pull request
