### PR TITLE
Allow timeseries total site energy use for residential_hpxml

### DIFF
--- a/buildstockbatch/workflow_generator/residential_hpxml.py
+++ b/buildstockbatch/workflow_generator/residential_hpxml.py
@@ -107,6 +107,7 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
 
         sim_out_rep_args = {
             'timeseries_frequency': 'none',
+            'include_timeseries_total_consumptions': False,
             'include_timeseries_fuel_consumptions': False,
             'include_timeseries_end_use_consumptions': True,
             'include_timeseries_emissions': False,

--- a/buildstockbatch/workflow_generator/test_workflow_generator.py
+++ b/buildstockbatch/workflow_generator/test_workflow_generator.py
@@ -337,6 +337,7 @@ def test_residential_hpxml(mocker):
                 },
                 'simulation_output_report': {
                     'timeseries_frequency': 'hourly',
+                    'include_timeseries_total_consumptions': True,
                     'include_timeseries_end_use_consumptions': True,
                     'include_timeseries_total_loads': True,
                     'include_timeseries_zone_temperatures': False,
@@ -374,6 +375,7 @@ def test_residential_hpxml(mocker):
     simulation_output_step = steps[2]
     assert(simulation_output_step['measure_dir_name'] == 'ReportSimulationOutput')
     assert(simulation_output_step['arguments']['timeseries_frequency'] == 'hourly')
+    assert(simulation_output_step['arguments']['include_timeseries_total_consumptions'] is True)
     assert(simulation_output_step['arguments']['include_timeseries_end_use_consumptions'] is True)
     assert(simulation_output_step['arguments']['include_timeseries_total_loads'] is True)
     assert(simulation_output_step['arguments']['include_timeseries_zone_temperatures'] is False)

--- a/docs/workflow_generators/residential_hpxml.rst
+++ b/docs/workflow_generators/residential_hpxml.rst
@@ -23,6 +23,7 @@ Configuration Example
 
         simulation_output_report:
           timeseries_frequency: hourly
+          include_timeseries_total_consumptions: true
           include_timeseries_fuel_consumptions: true
           include_timeseries_end_use_consumptions: true
           include_timeseries_emissions: true

--- a/docs/workflow_generators/residential_hpxml.rst
+++ b/docs/workflow_generators/residential_hpxml.rst
@@ -74,9 +74,9 @@ Arguments
   Note that the default behavior is to retain some files and remove others.
   See :ref:`server-dir-cleanup-defaults` for current defaults.
 
-.. _BuildExistingModel: https://github.com/NREL/resstock/blob/restructure-v3/measures/BuildExistingModel/measure.xml
-.. _ReportSimulationOutput: https://github.com/NREL/resstock/blob/restructure-v3/resources/hpxml-measures/ReportSimulationOutput/measure.xml
-.. _ServerDirectoryCleanup: https://github.com/NREL/resstock/blob/restructure-v3/measures/ServerDirectoryCleanup/measure.xml
+.. _BuildExistingModel: https://github.com/NREL/resstock/blob/develop/measures/BuildExistingModel/measure.xml
+.. _ReportSimulationOutput: https://github.com/NREL/resstock/blob/develop/resources/hpxml-measures/ReportSimulationOutput/measure.xml
+.. _ServerDirectoryCleanup: https://github.com/NREL/resstock/blob/develop/measures/ServerDirectoryCleanup/measure.xml
 
 .. _build-existing-model-defaults:
 


### PR DESCRIPTION
## Pull Request Description

Adds support for new `include_timeseries_total_consumptions` argument of the ReportSimulationOutput measure.

## Checklist

Not all may apply

- [x] Code changes (must work)
- [ ] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [ ] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/ci.yml` as necessary.
- [x] All other unit tests passing
- [ ] Update validation for project config yaml file changes
- [x] Update existing documentation
- [ ] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
- [ ] Add to the changelog_dev.rst file and propose migration text in the pull request
