### PR TITLE
Sample weight bug fix

### DIFF
--- a/buildstockbatch/workflow_generator/residential_hpxml.py
+++ b/buildstockbatch/workflow_generator/residential_hpxml.py
@@ -86,7 +86,7 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
 
         bld_exist_model_args = {
             'building_id': building_id,
-            'sample_weight': self.n_datapoints / self.cfg['baseline']['n_buildings_represented']
+            'sample_weight': self.cfg['baseline']['n_buildings_represented'] / self.n_datapoints
         }
         if 'measures_to_ignore' in workflow_args:
             bld_exist_model_args['measures_to_ignore'] = '|'.join(workflow_args['measures_to_ignore'])

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -36,3 +36,10 @@ Development Changelog
 
         Postprocessing can correctly handle assortment of upgrades with overlaping set of columns with missing and
         non-missing values.
+
+    .. change::
+        :tags: bugfix
+        :pullreq: 282
+        :tickets:
+
+        Fixes bug that would cause sample weight to be incorrect on the HPXML workflow.


### PR DESCRIPTION

## Pull Request Description

Fixes bug that caused sample weight to be inverse of what it should be. 

## Checklist

Not all may apply

- [x] Code changes (must work)
- [x] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [x] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/ci.yml` as necessary.
- [x] All other unit tests passing
- [ ] Update validation for project config yaml file changes
- [ ] Update existing documentation
- [x] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
- [x] Add to the changelog_dev.rst file and propose migration text in the pull request
