### PR TITLE
Anticipate 0.22 as next version

### DIFF
--- a/buildstockbatch/__version__.py
+++ b/buildstockbatch/__version__.py
@@ -4,7 +4,7 @@ import datetime as dt
 __title__ = 'buildstockbatch'
 __description__ = 'Executing BuildStock projects on batch infrastructure.'
 __url__ = 'http://github.com/NREL/buildstockbatch'
-__version__ = '0.22'
+__version__ = '0.21'
 __schema_version__ = '0.3'
 __author__ = 'Noel Merket'
 __author_email__ = 'noel.merket@nrel.gov'

--- a/buildstockbatch/__version__.py
+++ b/buildstockbatch/__version__.py
@@ -4,7 +4,7 @@ import datetime as dt
 __title__ = 'buildstockbatch'
 __description__ = 'Executing BuildStock projects on batch infrastructure.'
 __url__ = 'http://github.com/NREL/buildstockbatch'
-__version__ = '0.21'
+__version__ = '0.22'
 __schema_version__ = '0.3'
 __author__ = 'Noel Merket'
 __author_email__ = 'noel.merket@nrel.gov'

--- a/buildstockbatch/base.py
+++ b/buildstockbatch/base.py
@@ -588,25 +588,27 @@ class BuildStockBatchBase(object):
     @staticmethod
     def validate_resstock_version(project_file):
         """
-        Check
+        Checks the minimum required version of BuildStockBatch against the version being used
         """
         cfg = get_project_configuration(project_file)
 
-        versions = {}
-        with open(os.path.join(cfg['buildstock_directory'], 'resources/buildstock.rb'), 'r') as f:
-            for line in f:
-                line = line.strip()
-                for tool in ['ResStock_Version', 'BuildStockBatch_Version']:
-                    if line.startswith(tool):
-                        lhs, rhs = line.split('=')
-                        version, _ = rhs.split('#')
-                        versions[tool] = eval(version.strip())
-        ResStock_Version = versions['ResStock_Version']
-        BuildStockBatch_Version = versions['BuildStockBatch_Version']
-        if bsb_version < BuildStockBatch_Version:
-            val_err = f"BuildStockBatch version {BuildStockBatch_Version} or above is required" \
-                f" for ResStock version {ResStock_Version}"
-            raise ValidationError(val_err)
+        buildstock_rb = os.path.join(cfg['buildstock_directory'], 'resources/buildstock.rb')
+        if os.path.exists(buildstock_rb):
+            versions = {}
+            with open(buildstock_rb, 'r') as f:
+                for line in f:
+                    line = line.strip()
+                    for tool in ['ResStock_Version', 'BuildStockBatch_Version']:
+                        if line.startswith(tool):
+                            lhs, rhs = line.split('=')
+                            version, _ = rhs.split('#')
+                            versions[tool] = eval(version.strip())
+            ResStock_Version = versions['ResStock_Version']
+            BuildStockBatch_Version = versions['BuildStockBatch_Version']
+            if bsb_version < BuildStockBatch_Version:
+                val_err = f"BuildStockBatch version {BuildStockBatch_Version} or above is required" \
+                    f" for ResStock version {ResStock_Version}"
+                raise ValidationError(val_err)
 
         return True
 

--- a/buildstockbatch/base.py
+++ b/buildstockbatch/base.py
@@ -620,8 +620,10 @@ class BuildStockBatchBase(object):
         """
         cfg = get_project_configuration(project_file)
 
-        version_rb = os.path.join(cfg['buildstock_directory'],
-            'resources/hpxml-measures/HPXMLtoOpenStudio/resources/version.rb')
+        if not 'os_version' in cfg:
+            return True
+        version_path = 'resources/hpxml-measures/HPXMLtoOpenStudio/resources/version.rb'
+        version_rb = os.path.join(cfg['buildstock_directory'], version_path)
         if os.path.exists(version_rb):
             versions = {}
             with open(version_rb, 'r') as f:

--- a/buildstockbatch/base.py
+++ b/buildstockbatch/base.py
@@ -620,7 +620,8 @@ class BuildStockBatchBase(object):
         """
         cfg = get_project_configuration(project_file)
 
-        version_rb = os.path.join(cfg['buildstock_directory'], 'resources/hpxml-measures/HPXMLtoOpenStudio/resources/version.rb')
+        version_rb = os.path.join(cfg['buildstock_directory'],
+            'resources/hpxml-measures/HPXMLtoOpenStudio/resources/version.rb')
         if os.path.exists(version_rb):
             versions = {}
             with open(version_rb, 'r') as f:

--- a/buildstockbatch/base.py
+++ b/buildstockbatch/base.py
@@ -608,7 +608,7 @@ class BuildStockBatchBase(object):
             BuildStockBatch_Version = versions['BuildStockBatch_Version']
             if bsb_version < BuildStockBatch_Version:
                 val_err = f"BuildStockBatch version {BuildStockBatch_Version} or above is required" \
-                    f" for ResStock version {ResStock_Version}"
+                    f" for ResStock version {ResStock_Version}. Found {bsb_version}"
                 raise ValidationError(val_err)
 
         return True
@@ -620,8 +620,7 @@ class BuildStockBatchBase(object):
         """
         cfg = get_project_configuration(project_file)
 
-        if 'os_version' not in cfg:
-            return True
+        os_version = cfg.get('os_version', BuildStockBatchBase.DEFAULT_OS_VERSION)
         version_path = 'resources/hpxml-measures/HPXMLtoOpenStudio/resources/version.rb'
         version_rb = os.path.join(cfg['buildstock_directory'], version_path)
         if os.path.exists(version_rb):
@@ -629,14 +628,16 @@ class BuildStockBatchBase(object):
             with open(version_rb, 'r') as f:
                 for line in f:
                     line = line.strip()
-                    for tool in ['OS_Version']:
+                    for tool in ['OS_HPXML_Version', 'OS_Version']:
                         if line.startswith(tool):
                             lhs, rhs = line.split('=')
                             version, _ = rhs.split('#')
                             versions[tool] = eval(version.strip())
+            OS_HPXML_Version = versions['OS_HPXML_Version']
             OS_Version = versions['OS_Version']
-            if cfg['os_version'] != OS_Version:
-                val_err = f"OS version {OS_Version} is required"
+            if os_version != OS_Version:
+                val_err = f"OS version {OS_Version} is required" \
+                    f" for OS-HPXML version {OS_HPXML_Version}. Found {os_version}"
                 raise ValidationError(val_err)
 
         return True

--- a/buildstockbatch/base.py
+++ b/buildstockbatch/base.py
@@ -604,7 +604,9 @@ class BuildStockBatchBase(object):
         ResStock_Version = versions['ResStock_Version']
         BuildStockBatch_Version = versions['BuildStockBatch_Version']
         if bsb_version < BuildStockBatch_Version:
-            raise ValidationError(f"BuildStockBatch version {BuildStockBatch_Version} or above is required for ResStock version {ResStock_Version}")
+            val_err = f"BuildStockBatch version {BuildStockBatch_Version} or above is required" \
+                f" for ResStock version {ResStock_Version}"
+            raise ValidationError(val_err)
 
         return True
 

--- a/buildstockbatch/base.py
+++ b/buildstockbatch/base.py
@@ -620,7 +620,7 @@ class BuildStockBatchBase(object):
         """
         cfg = get_project_configuration(project_file)
 
-        if not 'os_version' in cfg:
+        if 'os_version' not in cfg:
             return True
         version_path = 'resources/hpxml-measures/HPXMLtoOpenStudio/resources/version.rb'
         version_rb = os.path.join(cfg['buildstock_directory'], version_path)

--- a/buildstockbatch/eagle.py
+++ b/buildstockbatch/eagle.py
@@ -37,6 +37,7 @@ import csv
 from buildstockbatch.base import BuildStockBatchBase, SimulationExists
 from buildstockbatch.utils import log_error_details, get_error_details, ContainerRuntime
 from buildstockbatch import postprocessing
+from buildstockbatch.__version__ import __version__ as bsb_version
 
 logger = logging.getLogger(__name__)
 
@@ -379,6 +380,8 @@ class EagleBatch(BuildStockBatchBase):
                 str(cls.local_singularity_img),
                 'bash', '-x'
             ])
+            env_vars = dict(os.environ)
+            env_vars['SINGULARITYENV_BUILDSTOCKBATCH_VERSION'] = bsb_version
             logger.debug('\n'.join(map(str, args)))
             with open(os.path.join(sim_dir, 'singularity_output.log'), 'w') as f_out:
                 try:
@@ -388,7 +391,8 @@ class EagleBatch(BuildStockBatchBase):
                         input='\n'.join(runscript).encode('utf-8'),
                         stdout=f_out,
                         stderr=subprocess.STDOUT,
-                        cwd=cls.local_output_dir
+                        cwd=cls.local_output_dir,
+                        env=env_vars,
                     )
                 except subprocess.CalledProcessError:
                     pass

--- a/buildstockbatch/localdocker.py
+++ b/buildstockbatch/localdocker.py
@@ -31,6 +31,7 @@ import tempfile
 from buildstockbatch.base import BuildStockBatchBase, SimulationExists
 from buildstockbatch import postprocessing
 from .utils import log_error_details, ContainerRuntime
+from buildstockbatch.__version__ import __version__ as bsb_version
 
 logger = logging.getLogger(__name__)
 
@@ -126,6 +127,10 @@ class LocalDockerBatch(DockerBatchBase):
         ]
         if measures_only:
             args.insert(2, '--measures_only')
+
+        env_vars = {}
+        env_vars['BUILDSTOCKBATCH_VERSION'] = bsb_version
+
         extra_kws = {}
         if sys.platform.startswith('linux'):
             extra_kws['user'] = f'{os.getuid()}:{os.getgid()}'
@@ -135,6 +140,7 @@ class LocalDockerBatch(DockerBatchBase):
             remove=True,
             volumes=docker_volume_mounts,
             name=sim_id,
+            environment=env_vars,
             **extra_kws
         )
         with open(os.path.join(sim_dir, 'docker_output.log'), 'wb') as f_out:


### PR DESCRIPTION
Fixes # .

## Pull Request Description

Update `__version__` to 0.22.

Create a `validate_resstock_version` method for checking current BuildstockBatch version against version required by ResStock.

Create a `validate_openstudio_version` method for checking current OpenStudio version against version required by OS-HPXML.

Pass `BUILDSTOCKBATCH_VERSION` env var through for eagle and localdocker (used by ResStock for checking version, which is useful for people trying to use old BuildstockBatch with new ResStock).

Companion PR: https://github.com/NREL/resstock/pull/938.

## Checklist

Not all may apply

- [ ] Code changes (must work)
- [ ] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [ ] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/ci.yml` as necessary.
- [ ] All other unit tests passing
- [ ] Update validation for project config yaml file changes
- [ ] Update existing documentation
- [ ] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
- [ ] Add to the changelog_dev.rst file and propose migration text in the pull request
