### PR TITLE
Add validation for common apply logic error.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
     name: Tests - Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2

--- a/buildstockbatch/base.py
+++ b/buildstockbatch/base.py
@@ -563,7 +563,7 @@ class BuildStockBatchBase(object):
         if 'downselect' in cfg or "downselect" in cfg.get('sampler', {}).get('type'):
             source_str = "in downselect logic"
             logic = cfg['downselect']['logic'] if 'downselect' in cfg else cfg['sampler']['args']['logic']
-            if problems := get_logic_problems(upgrade['package_apply_logic']):
+            if problems := get_logic_problems(logic):
                 all_problems.append((source_str, problems, logic))
 
         if all_problems:

--- a/buildstockbatch/test/test_inputs/complete-schema.yml
+++ b/buildstockbatch/test/test_inputs/complete-schema.yml
@@ -72,7 +72,7 @@ upgrades:
             - Lighting|100% LED, Low Efficacy
           - not: Lighting|100% CFL
           - not: Geometry Garage|3 Car
-          - and:
+          - or:
             - Lighting|60% CFL Hardwired, 34% CFL Plugin
             - Lighting|60% LED Hardwired, 34% CFL Plugin
           - Geometry Stories|1

--- a/buildstockbatch/test/test_inputs/enforce-validate-options-all-good.yml
+++ b/buildstockbatch/test/test_inputs/enforce-validate-options-all-good.yml
@@ -1,0 +1,26 @@
+buildstock_directory: test_openstudio_buildstock
+project_directory: project_singlefamilydetached
+baseline:
+  n_datapoints: 30
+  n_buildings_represented: 81221016
+  sampling_algorithm: quota
+upgrades:
+  - upgrade_name: good upgrade
+    options:
+      - option: Vintage|<1940
+        apply_logic:
+          - or:
+            - Insulation Slab|Good Option
+            - Insulation Slab|None
+          - not: Insulation Wall|Good Option
+          - and:
+              - Vintage|1960s||Vintage|1960s
+              - Insulation Slab|None
+      - option: Insulation Finished Basement|Good Option
+        apply_logic:
+          - Insulation Unfinished Basement|Extra Argument
+    package_apply_logic: Vintage|1960s||Vintage|1940s
+downselect:
+  logic: Vintage|2000s
+  resample: False
+schema_version: 0.3

--- a/buildstockbatch/test/test_inputs/enforce-validate-options-good.yml
+++ b/buildstockbatch/test/test_inputs/enforce-validate-options-good.yml
@@ -12,14 +12,16 @@ upgrades:
           - or:
             - Insulation Slab|Good Option
             - Insulation Slab|None
-          - not: Insulation Wall|Good Option
+          - not: 
+            - Insulation Wall|Good Option
+            - Insulation Wall|Good Option  # Two Insulation Wall under 'not'. Should be caught by logic validator
           - and:
               - Vintage|1960s||Vintage|1960s
-              - Vintage|1980s
+              - Vintage|1980s  # Two Vintages under and. Should be caught by logic validator
       - option: Insulation Finished Basement|Good Option
         apply_logic:
           - Insulation Unfinished Basement|Extra Argument
-    package_apply_logic: Vintage|1960s||Vintage|1940s
+    package_apply_logic: Vintage|1960s&&Vintage|1940s  # Two Vintages under 'and'. Should be caught by logic validator
 downselect:
   logic: Vintage|2000s
   resample: False

--- a/buildstockbatch/test/test_validation.py
+++ b/buildstockbatch/test/test_validation.py
@@ -146,7 +146,7 @@ def test_bad_measures(project_file):
             assert "Found unexpected argument key include_enduse_subcategory" in er
 
         else:
-            raise Exception("measures_and_arguments was supposed to raise ValueError for"
+            raise Exception("measures_and_arguments was supposed to raise ValidationError for"
                             " enforce-validate-measures-bad.yml")
 
 
@@ -186,7 +186,7 @@ def test_good_options_validation(project_file):
 def test_bad_options_validation(project_file):
     try:
         BuildStockBatchBase.validate_options_lookup(project_file)
-    except ValueError as er:
+    except ValidationError as er:
         er = str(er)
         assert "Insulation Slab(Good) Option" in er
         assert "Insulation Unfinished&Basement" in er
@@ -218,7 +218,7 @@ def test_good_measures_validation(project_file):
 def test_bad_measures_validation(project_file):
     try:
         BuildStockBatchBase.validate_measure_references(project_file)
-    except ValueError as er:
+    except ValidationError as er:
         er = str(er)
         assert "Measure directory" in er
         assert "not found" in er
@@ -240,4 +240,26 @@ def test_bad_postprocessing_spec_validation(project_file):
         er = str(er)
         assert "bad_partition_column" in er
     else:
-        raise Exception("validate_options was supposed to raise ValueError for enforce-validate-options-bad-2.yml")
+        raise Exception("validate_options was supposed to raise ValidationError for enforce-validate-options-bad-2.yml")
+
+
+@pytest.mark.parametrize("project_file", [
+    os.path.join(example_yml_dir, 'enforce-validate-options-good.yml')
+])
+def test_logic_validation_fail(project_file):
+    try:
+        BuildStockBatchBase.validate_logic(project_file)
+    except ValidationError as er:
+        er = str(er)
+        assert "'Insulation Wall' occurs 2 times in a 'not' block" in er
+        assert "'Vintage' occurs 2 times in a 'and' block" in er
+        assert "'Vintage' occurs 2 times in a '&&' block" in er
+    else:
+        raise Exception("validate_options was supposed to raise ValidationError for enforce-validate-options-good.yml")
+
+
+@pytest.mark.parametrize("project_file", [
+    os.path.join(example_yml_dir, 'enforce-validate-options-all-good.yml')
+])
+def test_logic_validation_pass(project_file):
+    BuildStockBatchBase.validate_logic(project_file)

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -67,3 +67,4 @@ Development Changelog
         :tickets:
 
         Add basic logic validation that checks for incorrect use of 'and' and 'not' block.
+        BSB requires at least python 3.8.

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -60,3 +60,10 @@ Development Changelog
         :tickets:
 
         For ResStock the OpenStudio version has changed to v3.4.0.
+
+    .. change::
+        :tags: general, feature
+        :pullreq: 295
+        :tickets:
+
+        Add basic logic validation that checks for incorrect use of 'and' and 'not' block.

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setuptools.setup(
     long_description_content_type='text/markdown',
     url=metadata['__url__'],
     packages=setuptools.find_packages(),
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     package_data={
         'buildstockbatch': ['*.sh', 'schemas/*.yaml'],
         '': ['LICENSE']


### PR DESCRIPTION
## Pull Request Description

Add validator for apply logic. Currently, validates that 'and' and 'not' block doesn't contain the same option more than once (which typically means it should have been 'or' block). 

## Checklist

Not all may apply

- [x] Code changes (must work)
- [x] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [x] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/ci.yml` as necessary.
- [x] All other unit tests passing
- [x] Update validation for project config yaml file changes
- [ ] Update existing documentation
- [x] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
- [ ] Add to the changelog_dev.rst file and propose migration text in the pull request
