### PR TITLE
Update create_eagle_env to use python=3.8

### DIFF
--- a/create_eagle_env.sh
+++ b/create_eagle_env.sh
@@ -26,7 +26,7 @@ MY_CONDA_PREFIX="$CONDA_ENVS_DIR/$MY_CONDA_ENV_NAME"
 echo "Creating $MY_CONDA_PREFIX"
 module load conda
 conda remove -y --prefix "$MY_CONDA_PREFIX" --all
-conda create -y --prefix "$MY_CONDA_PREFIX" -c conda-forge "pyarrow>=7.0.0" python=3.7.8 "numpy>=1.20.0" "pandas>=1.0.0,!=1.0.4" "dask>=2021.5" "distributed>=2021.5" ruby
+conda create -y --prefix "$MY_CONDA_PREFIX" -c conda-forge "pyarrow>=7.0.0" python=3.8 "numpy>=1.20.0" "pandas>=1.0.0,!=1.0.4" "dask>=2021.5" "distributed>=2021.5" ruby
 source deactivate 
 source activate "$MY_CONDA_PREFIX"
 which pip

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -22,7 +22,7 @@ computationally intensive. Local use is only recommended for very small testing 
    `Docker Desktop Community 2.1.0.5 <https://docs.docker.com/docker-for-windows/release-notes/#docker-desktop-community-2105>`_
    or below.
 
-Install Python 3.6 or greater for your platform. Either the official
+Install Python 3.8 or greater for your platform. Either the official
 distribution from python.org or the `Anaconda distribution
 <https://www.anaconda.com/distribution/>`_ (recommended).
 
@@ -31,7 +31,7 @@ Get a copy of this code either by downloading the zip file from GitHub or
 
 Optional, but highly recommended, is to create a new `python virtual
 environment`_ if you're using python from python.org, or to create a new `conda
-environment`_ if you're using Anaconda. Make sure you configure your virtual environment to use Python 3.6 or greater. Then activate your environment. 
+environment`_ if you're using Anaconda. Make sure you configure your virtual environment to use Python 3.8 or greater. Then activate your environment.
 
 .. _python virtual environment: https://docs.python.org/3/library/venv.html
 .. _conda environment: https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html


### PR DESCRIPTION
## Pull Request Description

I forgot to update the python version in create_eagle_env in this pull request: https://github.com/NREL/buildstockbatch/pull/295

Fixing that.

## Checklist

Not all may apply

- [ ] Code changes (must work)
- [ ] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [ ] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/ci.yml` as necessary.
- [ ] All other unit tests passing
- [ ] Update validation for project config yaml file changes
- [ ] Update existing documentation
- [ ] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
- [ ] Add to the changelog_dev.rst file and propose migration text in the pull request
