### PR TITLE
Add period beginning feature

### DIFF
--- a/buildstockbatch/aws/aws.py
+++ b/buildstockbatch/aws/aws.py
@@ -2063,6 +2063,7 @@ class AwsBatch(DockerBatchBase):
 
                 # Clean Up simulation directory
                 cls.cleanup_sim_dir(
+                    cfg,
                     sim_dir,
                     fs,
                     f"{bucket}/{prefix}/results/simulation_output/timeseries",

--- a/buildstockbatch/base.py
+++ b/buildstockbatch/base.py
@@ -171,7 +171,7 @@ class BuildStockBatchBase(object):
             diff = df['timedst'] - df['time']
             offset_diff = np.array([0] + list(diff.values)[:-1])
             df['time'] = df['time'] - step
-            df['timedst'] = df['time'] + np.array(offset_diff)
+            df['timedst'] = df['time'] + offset_diff
         else:
             df['time'] = df['time'] - step
 
@@ -244,7 +244,7 @@ class BuildStockBatchBase(object):
                 return x.lower()
 
             tsdf.rename(columns=get_clean_column_name, inplace=True)
-            if cfg.get("postprocessing", {}).get("timestamps_uses_period_beginning", False):
+            if cfg.get("postprocessing", {}).get("timestamps_use_period_beginning", False):
                 BuildStockBatchBase.make_period_beginning(tsdf)
             postprocessing.write_dataframe_as_parquet(
                 tsdf,

--- a/buildstockbatch/base.py
+++ b/buildstockbatch/base.py
@@ -180,8 +180,8 @@ class BuildStockBatchBase(object):
 
         return df
 
-    @staticmethod
-    def cleanup_sim_dir(cfg, sim_dir, dest_fs, simout_ts_dir, upgrade_id, building_id):
+    @classmethod
+    def cleanup_sim_dir(cls, cfg, sim_dir, dest_fs, simout_ts_dir, upgrade_id, building_id):
         """Clean up the output directory for a single simulation.
 
         :param sim_dir: simulation directory
@@ -245,7 +245,7 @@ class BuildStockBatchBase(object):
 
             tsdf.rename(columns=get_clean_column_name, inplace=True)
             if cfg.get("postprocessing", {}).get("timestamps_use_period_beginning", False):
-                BuildStockBatchBase.make_period_beginning(tsdf)
+                cls.make_period_beginning(tsdf)
             postprocessing.write_dataframe_as_parquet(
                 tsdf,
                 dest_fs,

--- a/buildstockbatch/eagle.py
+++ b/buildstockbatch/eagle.py
@@ -406,6 +406,7 @@ class EagleBatch(BuildStockBatchBase):
 
                     # Clean up simulation directory
                     cls.cleanup_sim_dir(
+                        cfg,
                         sim_dir,
                         fs,
                         f'{output_dir}/results/simulation_output/timeseries',

--- a/buildstockbatch/localdocker.py
+++ b/buildstockbatch/localdocker.py
@@ -152,6 +152,7 @@ class LocalDockerBatch(DockerBatchBase):
 
         fs = LocalFileSystem()
         cls.cleanup_sim_dir(
+            cfg,
             sim_dir,
             fs,
             f"{results_dir}/simulation_output/timeseries",

--- a/buildstockbatch/schemas/v0.3.yaml
+++ b/buildstockbatch/schemas/v0.3.yaml
@@ -109,6 +109,7 @@ postprocessing-spec:
   partition_columns: list(str(), required=False)
   aws: include('aws-postprocessing-spec', required=False)
   keep_individual_timeseries: bool(required=False)
+  timestamps_uses_period_beginning: bool(required=False)
 
 aws-postprocessing-spec:
   region_name: str(required=False)

--- a/buildstockbatch/schemas/v0.3.yaml
+++ b/buildstockbatch/schemas/v0.3.yaml
@@ -109,7 +109,7 @@ postprocessing-spec:
   partition_columns: list(str(), required=False)
   aws: include('aws-postprocessing-spec', required=False)
   keep_individual_timeseries: bool(required=False)
-  timestamps_uses_period_beginning: bool(required=False)
+  timestamps_use_period_beginning: bool(required=False)
 
 aws-postprocessing-spec:
   region_name: str(required=False)

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -68,3 +68,10 @@ Development Changelog
 
         Add basic logic validation that checks for incorrect use of 'and' and 'not' block.
         BSB requires at least python 3.8.
+
+    .. change::
+        :tags: general, feature
+        :pullreq: 301
+        :tickets:
+
+        Add ``timestamps_use_period_beginning`` argument to postprocessing spec.

--- a/docs/project_defn.rst
+++ b/docs/project_defn.rst
@@ -264,6 +264,9 @@ The configuration options for postprocessing and AWS upload are:
       must match the parameters found in options_lookup.tsv. This allows for efficient athena queries. Only recommended
       for moderate or large sized runs (ndatapoints > 10K)
 
+    * ``timestamps_use_period_beginning``: (optional, bool) Set this to ``true`` to use the period beginning timestamps.
+      Default is ``false``.
+
     * ``aws``: (optional) configuration related to uploading to and managing data in amazon web services. For this to
        work, please `configure aws. <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/quickstart.html#configuration>`_
        Including this key will cause your datasets to be uploaded to AWS, omitting it will cause them not to be uploaded.


### PR DESCRIPTION
## Pull Request Description

Currently, OS-HPXML outputs timestamps in period ending format. This PR enables converting them to period beginning format. We require period beginning for LA100ES project. 

## Checklist

Not all may apply

- [x] Code changes (must work)
- [ ] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [x] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/ci.yml` as necessary.
- [x] All other unit tests passing
- [x] Update validation for project config yaml file changes
- [x] Update existing documentation
- [x] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
- [x] Add to the changelog_dev.rst file and propose migration text in the pull request
