### PR TITLE
Move HPXMLtoOpenStudio to top level

### DIFF
--- a/buildstockbatch/localdocker.py
+++ b/buildstockbatch/localdocker.py
@@ -114,7 +114,9 @@ class LocalDockerBatch(DockerBatchBase):
             if not os.path.exists(dir_to_make):
                 os.makedirs(dir_to_make)
 
-        osw = cls.create_osw(cfg, n_datapoints, sim_id, building_id=i, upgrade_idx=upgrade_idx)
+        output_dir = '../../../run'
+        hpxml_path = '../../../run/in.xml'
+        osw = cls.create_osw(cfg, n_datapoints, sim_id, building_id=i, hpxml_path=hpxml_path, output_dir=output_dir, upgrade_idx=upgrade_idx)
 
         with open(os.path.join(sim_dir, 'in.osw'), 'w') as f:
             json.dump(osw, f, indent=4)

--- a/buildstockbatch/localdocker.py
+++ b/buildstockbatch/localdocker.py
@@ -114,9 +114,7 @@ class LocalDockerBatch(DockerBatchBase):
             if not os.path.exists(dir_to_make):
                 os.makedirs(dir_to_make)
 
-        output_dir = '../../../run'
-        hpxml_path = '../../../run/in.xml'
-        osw = cls.create_osw(cfg, n_datapoints, sim_id, building_id=i, hpxml_path=hpxml_path, output_dir=output_dir, upgrade_idx=upgrade_idx)
+        osw = cls.create_osw(cfg, n_datapoints, sim_id, building_id=i, upgrade_idx=upgrade_idx)
 
         with open(os.path.join(sim_dir, 'in.osw'), 'w') as f:
             json.dump(osw, f, indent=4)

--- a/buildstockbatch/workflow_generator/residential_hpxml.py
+++ b/buildstockbatch/workflow_generator/residential_hpxml.py
@@ -31,7 +31,6 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
         :type cfg: dict
         """
         schema_yml = """
-        measures_to_ignore: list(str(), required=False)
         build_existing_model: map(required=False)
         emissions: list(include('scenario-spec'), required=False)
         measures: list(include('measure-spec'), required=False)
@@ -83,14 +82,21 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
 
         logger.debug('Generating OSW, sim_id={}'.format(sim_id))
 
-        sim_ctl_args = {}
+        sim_ctl_args = {
+            'simulation_control_timestep': 60,
+            'simulation_control_run_period_begin_month': 1,
+            'simulation_control_run_period_begin_day_of_month': 1,
+            'simulation_control_run_period_end_month': 12,
+            'simulation_control_run_period_end_day_of_month': 31,
+            'simulation_control_run_period_calendar_year': 2007,
+            'add_component_loads': False
+        }
 
         bld_exist_model_args = {
             'building_id': building_id,
             'sample_weight': self.cfg['baseline']['n_buildings_represented'] / self.n_datapoints
         }
-        if 'measures_to_ignore' in workflow_args:
-            bld_exist_model_args['measures_to_ignore'] = '|'.join(workflow_args['measures_to_ignore'])
+
         bld_exist_model_args.update(sim_ctl_args)
         bld_exist_model_args.update(workflow_args['build_existing_model'])
 

--- a/buildstockbatch/workflow_generator/residential_hpxml.py
+++ b/buildstockbatch/workflow_generator/residential_hpxml.py
@@ -181,7 +181,7 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
             {
                 'measure_dir_name': 'HPXMLtoOpenStudio',
                 'arguments': {
-                    'hpxml_path': '../../../run/in.xml',
+                    'hpxml_path': '../../../run/home.xml',
                     'output_dir': '../../../run',
                     'debug': debug
                 }

--- a/buildstockbatch/workflow_generator/residential_hpxml.py
+++ b/buildstockbatch/workflow_generator/residential_hpxml.py
@@ -192,8 +192,8 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
             {
                 'measure_dir_name': 'HPXMLtoOpenStudio',
                 'arguments': {
-                    'hpxml_path': '../../../run/home.xml',
-                    'output_dir': '../../../run',
+                    'hpxml_path': '../../run/home.xml',
+                    'output_dir': '../../run',
                     'debug': debug,
                     'add_component_loads': add_component_loads
                 }

--- a/buildstockbatch/workflow_generator/residential_hpxml.py
+++ b/buildstockbatch/workflow_generator/residential_hpxml.py
@@ -100,6 +100,11 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
         bld_exist_model_args.update(sim_ctl_args)
         bld_exist_model_args.update(workflow_args['build_existing_model'])
 
+        add_component_loads = False
+        if 'add_component_loads' in bld_exist_model_args:
+            add_component_loads = bld_exist_model_args['add_component_loads']
+            bld_exist_model_args.pop('add_component_loads')
+
         if 'emissions' in workflow_args:
             emissions = workflow_args['emissions']
             emissions_map = [['emissions_scenario_names', 'scenario_name'],
@@ -189,7 +194,8 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
                 'arguments': {
                     'hpxml_path': '../../../run/home.xml',
                     'output_dir': '../../../run',
-                    'debug': debug
+                    'debug': debug,
+                    'add_component_loads': add_component_loads
                 }
             },
             {

--- a/buildstockbatch/workflow_generator/residential_hpxml.py
+++ b/buildstockbatch/workflow_generator/residential_hpxml.py
@@ -38,7 +38,7 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
         reporting_measures: list(include('measure-spec'), required=False)
         simulation_output_report: map(required=False)
         server_directory_cleanup: map(required=False)
-        debug: str(required=False)
+        debug: bool(required=False)
         ---
         scenario-spec:
             scenario_name: str(required=True)

--- a/buildstockbatch/workflow_generator/residential_hpxml.py
+++ b/buildstockbatch/workflow_generator/residential_hpxml.py
@@ -38,6 +38,7 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
         reporting_measures: list(include('measure-spec'), required=False)
         simulation_output_report: map(required=False)
         server_directory_cleanup: map(required=False)
+        debug: str(required=False)
         ---
         scenario-spec:
             scenario_name: str(required=True)
@@ -149,6 +150,10 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
 
         osw['steps'].extend(workflow_args['measures'])
 
+        debug = False
+        if 'debug' in workflow_args:
+            debug = workflow_args['debug']
+
         server_dir_cleanup_args = {
           'retain_in_osm': False,
           'retain_in_idf': True,
@@ -167,7 +172,8 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
           'retain_eplustbl_htm': False,
           'retain_stdout_energyplus': False,
           'retain_stdout_expandobject': False,
-          'retain_schedules_csv': True
+          'retain_schedules_csv': True,
+          'debug': debug
         }
         server_dir_cleanup_args.update(workflow_args['server_directory_cleanup'])
 
@@ -176,7 +182,8 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
                 'measure_dir_name': 'HPXMLtoOpenStudio',
                 'arguments': {
                     'hpxml_path': '../../../run/in.xml',
-                    'output_dir': '../../../run'
+                    'output_dir': '../../../run',
+                    'debug': debug
                 }
             },
             {
@@ -189,7 +196,9 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
             },
             {
                 'measure_dir_name': 'UpgradeCosts',
-                'arguments': {}
+                'arguments': {
+                    'debug': debug
+                }
             },
             {
                 'measure_dir_name': 'ServerDirectoryCleanup',

--- a/buildstockbatch/workflow_generator/residential_hpxml.py
+++ b/buildstockbatch/workflow_generator/residential_hpxml.py
@@ -63,14 +63,12 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
         workflow_args = self.cfg['workflow_generator'].get('args', {})
         return [x['measure_dir_name'] for x in workflow_args.get('reporting_measures', [])]
 
-    def create_osw(self, sim_id, building_id, hpxml_path, output_dir, upgrade_idx):
+    def create_osw(self, sim_id, building_id, upgrade_idx):
         """
         Generate and return the osw as a python dict
 
         :param sim_id: simulation id, looks like 'bldg0000001up01'
         :param building_id: integer building id to use from the sampled buildstock.csv
-        :param hpxml_path: HPXMLtoOpenStudio argument for location of HPXML file
-        :param output_dir: HPXMLtoOpenStudio argument for location of run directory
         :param upgrade_idx: integer index of the upgrade scenario to apply, None if baseline
         """
         # Default argument values
@@ -177,8 +175,8 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
             {
                 'measure_dir_name': 'HPXMLtoOpenStudio',
                 'arguments': {
-                    'hpxml_path': hpxml_path,
-                    'output_dir': output_dir
+                    'hpxml_path': '../../../run/in.xml',
+                    'output_dir': '../../../run'
                 }
             },
             {

--- a/buildstockbatch/workflow_generator/residential_hpxml.py
+++ b/buildstockbatch/workflow_generator/residential_hpxml.py
@@ -63,12 +63,14 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
         workflow_args = self.cfg['workflow_generator'].get('args', {})
         return [x['measure_dir_name'] for x in workflow_args.get('reporting_measures', [])]
 
-    def create_osw(self, sim_id, building_id, upgrade_idx):
+    def create_osw(self, sim_id, building_id, hpxml_path, output_dir, upgrade_idx):
         """
         Generate and return the osw as a python dict
 
         :param sim_id: simulation id, looks like 'bldg0000001up01'
         :param building_id: integer building id to use from the sampled buildstock.csv
+        :param hpxml_path: HPXMLtoOpenStudio argument for location of HPXML file
+        :param output_dir: HPXMLtoOpenStudio argument for location of run directory
         :param upgrade_idx: integer index of the upgrade scenario to apply, None if baseline
         """
         # Default argument values
@@ -172,6 +174,13 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
         server_dir_cleanup_args.update(workflow_args['server_directory_cleanup'])
 
         osw['steps'].extend([
+            {
+                'measure_dir_name': 'HPXMLtoOpenStudio',
+                'arguments': {
+                    'hpxml_path': hpxml_path,
+                    'output_dir': output_dir
+                }
+            },
             {
                 'measure_dir_name': 'ReportSimulationOutput',
                 'arguments': sim_out_rep_args

--- a/buildstockbatch/workflow_generator/test_workflow_generator.py
+++ b/buildstockbatch/workflow_generator/test_workflow_generator.py
@@ -359,7 +359,7 @@ def test_residential_hpxml(mocker):
     osw = osw_gen.create_osw(sim_id, building_id, upgrade_idx)
 
     steps = osw['steps']
-    assert(len(steps) == 6)
+    assert(len(steps) == 7)
 
     build_existing_model_step = steps[0]
     assert(build_existing_model_step['measure_dir_name'] == 'BuildExistingModel')

--- a/buildstockbatch/workflow_generator/test_workflow_generator.py
+++ b/buildstockbatch/workflow_generator/test_workflow_generator.py
@@ -372,8 +372,8 @@ def test_residential_hpxml(mocker):
     apply_upgrade_step = steps[1]
     assert apply_upgrade_step['measure_dir_name'] == 'ApplyUpgrade'
 
-    apply_upgrade_step = steps[2]
-    assert apply_upgrade_step['measure_dir_name'] == 'HPXMLtoOpenStudio'
+    hpxml_to_os_step = steps[2]
+    assert hpxml_to_os_step['measure_dir_name'] == 'HPXMLtoOpenStudio'
 
     simulation_output_step = steps[3]
     assert simulation_output_step['measure_dir_name'] == 'ReportSimulationOutput'

--- a/buildstockbatch/workflow_generator/test_workflow_generator.py
+++ b/buildstockbatch/workflow_generator/test_workflow_generator.py
@@ -372,7 +372,10 @@ def test_residential_hpxml(mocker):
     apply_upgrade_step = steps[1]
     assert(apply_upgrade_step['measure_dir_name'] == 'ApplyUpgrade')
 
-    simulation_output_step = steps[2]
+    apply_upgrade_step = steps[2]
+    assert(apply_upgrade_step['measure_dir_name'] == 'HPXMLtoOpenStudio')
+
+    simulation_output_step = steps[3]
     assert(simulation_output_step['measure_dir_name'] == 'ReportSimulationOutput')
     assert(simulation_output_step['arguments']['timeseries_frequency'] == 'hourly')
     assert(simulation_output_step['arguments']['include_timeseries_total_consumptions'] is True)
@@ -390,13 +393,13 @@ def test_residential_hpxml(mocker):
     assert(simulation_output_step['arguments']['add_timeseries_dst_column'] is True)
     assert(simulation_output_step['arguments']['add_timeseries_utc_column'] is True)
 
-    hpxml_output_step = steps[3]
+    hpxml_output_step = steps[4]
     assert(hpxml_output_step['measure_dir_name'] == 'ReportHPXMLOutput')
 
-    upgrade_costs_step = steps[4]
+    upgrade_costs_step = steps[5]
     assert(upgrade_costs_step['measure_dir_name'] == 'UpgradeCosts')
 
-    server_dir_cleanup_step = steps[5]
+    server_dir_cleanup_step = steps[6]
     assert(server_dir_cleanup_step['measure_dir_name'] == 'ServerDirectoryCleanup')
 
 

--- a/docs/workflow_generators/residential_hpxml.rst
+++ b/docs/workflow_generators/residential_hpxml.rst
@@ -35,6 +35,8 @@ Configuration Example
           retain_in_idf: false
           retain_eplusout_rdd: true
 
+        debug: false
+
 Arguments
 ~~~~~~~~~
 
@@ -61,7 +63,7 @@ Arguments
 
   - ``output_variables``: Optionally request EnergyPlus output variables. Do not include key values; by default all key values will be requested.
 
-- ``reporting_measures`` (optional): a list of reporting measures to apply
+- ``reporting_measures`` (optional): A list of reporting measures to apply
   to the workflow. Any columns reported by these additional measures will be
   appended to the results csv. Note: For upgrade runs, do not add
   ``ApplyUpgrade`` to the list of reporting measures, doing so will cause run
@@ -71,12 +73,17 @@ Arguments
   - ``measure_dir_name``: Name of measure directory.
   - ``arguments``: map of key, value arguments to pass to the measure.
 
-- ``server_directory_cleanup`` (optional): optionally preserve or delete
+- ``server_directory_cleanup`` (optional): Optionally preserve or delete
   various simulation output files. These arguments are passed directly to
   the `ServerDirectoryCleanup`_ measure in resstock. Please refer to the
   measure arguments there to determine what to set them to in your config file.
   Note that the default behavior is to retain some files and remove others.
   See :ref:`server-dir-cleanup-defaults` for current defaults.
+
+- ``debug`` (optional): Optionally enable debug mode. Enabling debug
+  mode will preserve all simulation input and output files, including but
+  not limited to: in.osm, all EnergyPlus output files, and intermediate
+  existing and upgraded files (e.g., OSWs and XMLs).
 
 .. _BuildExistingModel: https://github.com/NREL/resstock/blob/develop/measures/BuildExistingModel/measure.xml
 .. _ReportSimulationOutput: https://github.com/NREL/resstock/blob/develop/resources/hpxml-measures/ReportSimulationOutput/measure.xml

--- a/docs/workflow_generators/residential_hpxml.rst
+++ b/docs/workflow_generators/residential_hpxml.rst
@@ -11,6 +11,7 @@ Configuration Example
       args:
         build_existing_model:
           simulation_control_run_period_calendar_year: 2010
+          add_component_loads: false
 
         emissions:
           - scenario_name: Scenario1


### PR DESCRIPTION
## Pull Request Description

Companion: https://github.com/NREL/resstock/pull/971

Also consolidates all existing debug arguments (for example, those for `build_existing_model` and `server_directory_cleanup`) into a single `debug` argument stored at the top level of the workflow generator. It optionally enables debug mode across multiple workflow measures. See the companion PR for more information.

## Checklist

Not all may apply

- [ ] Code changes (must work)
- [ ] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [ ] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/ci.yml` as necessary.
- [ ] All other unit tests passing
- [ ] Update validation for project config yaml file changes
- [ ] Update existing documentation
- [ ] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
- [ ] Add to the changelog_dev.rst file and propose migration text in the pull request
