### PR TITLE
Add ability to rerun failed array jobs

### DIFF
--- a/buildstockbatch/base.py
+++ b/buildstockbatch/base.py
@@ -249,18 +249,18 @@ class BuildStockBatchBase(object):
 
     @staticmethod
     def validate_project(project_file):
-        assert(BuildStockBatchBase.validate_project_schema(project_file))
-        assert(BuildStockBatchBase.validate_sampler(project_file))
-        assert(BuildStockBatchBase.validate_workflow_generator(project_file))
-        assert(BuildStockBatchBase.validate_misc_constraints(project_file))
-        assert(BuildStockBatchBase.validate_xor_nor_schema_keys(project_file))
-        assert(BuildStockBatchBase.validate_reference_scenario(project_file))
-        assert(BuildStockBatchBase.validate_options_lookup(project_file))
-        assert(BuildStockBatchBase.validate_logic(project_file))
-        assert(BuildStockBatchBase.validate_measure_references(project_file))
-        assert(BuildStockBatchBase.validate_postprocessing_spec(project_file))
-        assert(BuildStockBatchBase.validate_resstock_version(project_file))
-        assert(BuildStockBatchBase.validate_openstudio_version(project_file))
+        assert BuildStockBatchBase.validate_project_schema(project_file)
+        assert BuildStockBatchBase.validate_sampler(project_file)
+        assert BuildStockBatchBase.validate_workflow_generator(project_file)
+        assert BuildStockBatchBase.validate_misc_constraints(project_file)
+        assert BuildStockBatchBase.validate_xor_nor_schema_keys(project_file)
+        assert BuildStockBatchBase.validate_reference_scenario(project_file)
+        assert BuildStockBatchBase.validate_options_lookup(project_file)
+        assert BuildStockBatchBase.validate_logic(project_file)
+        assert BuildStockBatchBase.validate_measure_references(project_file)
+        assert BuildStockBatchBase.validate_postprocessing_spec(project_file)
+        assert BuildStockBatchBase.validate_resstock_version(project_file)
+        assert BuildStockBatchBase.validate_openstudio_version(project_file)
         logger.info('Base Validation Successful')
         return True
 

--- a/buildstockbatch/eagle.py
+++ b/buildstockbatch/eagle.py
@@ -320,6 +320,8 @@ class EagleBatch(BuildStockBatchBase):
         if os.path.exists(traceback_file_path):
             shutil.copy2(traceback_file_path, lustre_sim_out_dir)
 
+        logger.info(f'batch complete')
+
     @classmethod
     def run_building(cls, output_dir, cfg, n_datapoints, i, upgrade_idx=None):
 
@@ -579,9 +581,7 @@ class EagleBatch(BuildStockBatchBase):
         failed_job_ids = []
         for filename in job_out_files:
             with open(filename, 'r') as f:
-                # TODO: Make this look for successful ones instead.
-                # TODO: Or ones that are missing altogether.
-                if re.search(r"^Traceback \(most recent call last\):", f.read(), re.MULTILINE):
+                if not re.search(r"batch complete", f.read()):
                     job_id = int(re.match(r"job\.out-(\d+)", filename.name).group(1))
                     logger.debug(f"Array Job ID {job_id} had a failure.")
                     failed_job_ids.append(job_id)

--- a/buildstockbatch/eagle.py
+++ b/buildstockbatch/eagle.py
@@ -86,7 +86,7 @@ class EagleBatch(BuildStockBatchBase):
     @property
     def results_dir(self):
         results_dir = os.path.join(self.output_dir, 'results')
-        assert(os.path.isdir(results_dir))
+        assert os.path.isdir(results_dir)
         return results_dir
 
     @staticmethod
@@ -320,7 +320,7 @@ class EagleBatch(BuildStockBatchBase):
         if os.path.exists(traceback_file_path):
             shutil.copy2(traceback_file_path, lustre_sim_out_dir)
 
-        logger.info(f'batch complete')
+        logger.info('batch complete')
 
     @classmethod
     def run_building(cls, output_dir, cfg, n_datapoints, i, upgrade_idx=None):
@@ -601,7 +601,6 @@ class EagleBatch(BuildStockBatchBase):
         prev_failed_job_out_dir = output_path / 'prev_failed_jobs'
         os.makedirs(prev_failed_job_out_dir, exist_ok=True)
         for job_array_id in failed_job_array_ids:
-    
             # Move the failed job.out file so it doesn't get overwritten
             filepath = output_path / f'job.out-{job_array_id}'
             last_mod_date = dt.datetime.fromtimestamp(os.path.getmtime(filepath))
@@ -741,7 +740,7 @@ def user_cli(argv=sys.argv[1:]):
     # otherwise, queue up the whole eagle buildstockbatch process
     # the main work of the first Eagle job is to run the sampling script ...
     eagle_sh = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'eagle.sh')
-    assert(os.path.exists(eagle_sh))
+    assert os.path.exists(eagle_sh)
     out_dir = cfg['output_directory']
     if os.path.exists(out_dir):
         raise FileExistsError(
@@ -807,14 +806,14 @@ def main():
     if job_array_number:
         # if job array number is non-zero, run the batch job
         # Simulation should not be scheduled for sampling only
-        assert(not sampling_only)
+        assert not sampling_only
         batch.run_job_batch(job_array_number)
     elif post_process:
         logger.debug("Starting postprocessing")
         # else, we might be in a post-processing step
         # Postprocessing should not have been scheduled if measures only or sampling only are run
-        assert(not measures_only)
-        assert(not sampling_only)
+        assert not measures_only
+        assert not sampling_only
         if upload_only:
             batch.process_results(skip_combine=True, force_upload=True)
         else:

--- a/buildstockbatch/eagle.py
+++ b/buildstockbatch/eagle.py
@@ -562,6 +562,17 @@ class EagleBatch(BuildStockBatchBase):
         else:
             return Client(scheduler_file=os.path.join(self.output_dir, 'dask_scheduler.json'))
 
+    def process_results(self, *args, **kwargs):
+        # Check that all the jobs succeeded before proceeding
+        failed_job_array_ids = self.get_failed_job_array_ids()
+        if failed_job_array_ids:
+            logger.error("The following simulation jobs failed: {}".format(", ".join(failed_job_array_ids)))
+            logger.error("Please inspect those jobs and fix any problems before resubmitting.")
+            logger.critical("Postprocessing cancelled.")
+            return False
+
+        super().process_results(*args, **kwargs)
+
     def get_failed_job_array_ids(self):
         job_out_files = sorted(pathlib.Path(self.output_dir).glob('job.out-*'))
 

--- a/buildstockbatch/eagle.py
+++ b/buildstockbatch/eagle.py
@@ -568,7 +568,7 @@ class EagleBatch(BuildStockBatchBase):
         # Check that all the jobs succeeded before proceeding
         failed_job_array_ids = self.get_failed_job_array_ids()
         if failed_job_array_ids:
-            logger.error("The following simulation jobs failed: {}".format(", ".join(failed_job_array_ids)))
+            logger.error("The following simulation jobs failed: {}".format(", ".join(map(str, failed_job_array_ids))))
             logger.error("Please inspect those jobs and fix any problems before resubmitting.")
             logger.critical("Postprocessing cancelled.")
             return False

--- a/buildstockbatch/eagle.sh
+++ b/buildstockbatch/eagle.sh
@@ -6,6 +6,8 @@ echo "Job ID: $SLURM_JOB_ID"
 echo "Hostname: $HOSTNAME"
 echo "QOS: $SLURM_JOB_QOS"
 
+df -i
+
 module load conda singularity-container
 source activate "$MY_CONDA_ENV"
 

--- a/buildstockbatch/eagle.sh
+++ b/buildstockbatch/eagle.sh
@@ -7,6 +7,7 @@ echo "Hostname: $HOSTNAME"
 echo "QOS: $SLURM_JOB_QOS"
 
 df -i
+df -h
 
 module load conda singularity-container
 source activate "$MY_CONDA_ENV"

--- a/buildstockbatch/eagle_postprocessing.sh
+++ b/buildstockbatch/eagle_postprocessing.sh
@@ -4,6 +4,9 @@ echo "begin eagle_postprocessing.sh"
 echo "Job ID: $SLURM_JOB_ID"
 echo "Hostname: $HOSTNAME"
 
+df -i
+df -h
+
 module load conda singularity-container
 source activate "$MY_CONDA_ENV"
 
@@ -21,6 +24,7 @@ echo "workers"
 echo $SLURM_JOB_NODELIST_PACK_GROUP_1
 
 pdsh -w $SLURM_JOB_NODELIST_PACK_GROUP_1 "free -h"
+pdsh -w $SLURM_JOB_NODELIST_PACK_GROUP_1 "df -i; df -h"
 
 $MY_CONDA_ENV/bin/dask-scheduler --scheduler-file $SCHEDULER_FILE &> $OUT_DIR/dask_scheduler.out &
 pdsh -w $SLURM_JOB_NODELIST_PACK_GROUP_1 "$MY_CONDA_ENV/bin/dask-worker --scheduler-file $SCHEDULER_FILE --local-directory /tmp/scratch/dask --nprocs ${NPROCS} --nthreads 1 --memory-limit ${MEMORY}MB" &> $OUT_DIR/dask_workers.out &

--- a/buildstockbatch/test/test_base.py
+++ b/buildstockbatch/test/test_base.py
@@ -168,7 +168,7 @@ def test_downselect_integer_options(basic_residential_project_file, mocker):
         with open(buildstock_csv, 'r', newline='') as f:
             cf = csv.DictReader(f)
             for row in cf:
-                assert(row['Days Shifted'] in valid_option_values)
+                assert row['Days Shifted'] in valid_option_values
 
 
 def test_combine_files(basic_residential_project_file):
@@ -384,16 +384,16 @@ def test_skipping_baseline(basic_residential_project_file):
         get_dask_client_mock.assert_called_once()
 
     up00_parquet = os.path.join(results_dir, 'parquet', 'baseline', 'results_up00.parquet')
-    assert(not os.path.exists(up00_parquet))
+    assert not os.path.exists(up00_parquet)
 
     up01_parquet = os.path.join(results_dir, 'parquet', 'upgrades', 'upgrade=1', 'results_up01.parquet')
-    assert(os.path.exists(up01_parquet))
+    assert os.path.exists(up01_parquet)
 
     up00_csv_gz = os.path.join(results_dir, 'results_csvs', 'results_up00.csv.gz')
-    assert(not os.path.exists(up00_csv_gz))
+    assert not os.path.exists(up00_csv_gz)
 
     up01_csv_gz = os.path.join(results_dir, 'results_csvs', 'results_up01.csv.gz')
-    assert(os.path.exists(up01_csv_gz))
+    assert os.path.exists(up01_csv_gz)
 
 
 def test_provide_buildstock_csv(basic_residential_project_file, mocker):

--- a/buildstockbatch/test/test_docker.py
+++ b/buildstockbatch/test/test_docker.py
@@ -19,7 +19,7 @@ def test_docker_image_exists_on_docker_hub(basic_residential_project_file):
         docker_tag = bsb.os_version
         baseurl = 'https://registry.hub.docker.com/v2/'
         r1 = requests.get(baseurl)
-        assert(r1.status_code == 401)
+        assert r1.status_code == 401
         m = re.search(r'realm="(.+?)"', r1.headers['Www-Authenticate'])
         authurl = m.group(1)
         m = re.search(r'service="(.+?)"', r1.headers['Www-Authenticate'])
@@ -28,10 +28,10 @@ def test_docker_image_exists_on_docker_hub(basic_residential_project_file):
             'service': service,
             'scope': f'repository:{docker_image}:pull'
         })
-        assert(r2.ok)
+        assert r2.ok
         token = r2.json()['token']
         r3 = requests.head(
             f'{baseurl}{docker_image}/manifests/{docker_tag}',
             headers={'Authorization': f'Bearer {token}'}
         )
-        assert(r3.ok)
+        assert r3.ok

--- a/buildstockbatch/test/test_eagle.py
+++ b/buildstockbatch/test/test_eagle.py
@@ -58,14 +58,14 @@ def test_hpc_run_building(mock_subprocess, monkeypatch, basic_residential_projec
             'bash', '-x'
         ]
         mock_subprocess.run.assert_called_once()
-        assert(mock_subprocess.run.call_args[0][0] == expected_singularity_args)
+        assert mock_subprocess.run.call_args[0][0] == expected_singularity_args
         called_kw = mock_subprocess.run.call_args[1]
-        assert(called_kw.get('check') is True)
-        assert('input' in called_kw)
-        assert('stdout' in called_kw)
-        assert('stderr' in called_kw)
-        assert(str(called_kw.get('cwd')) == '/tmp/scratch/output')
-        assert(called_kw['input'].decode('utf-8').find(' --measures_only') == -1)
+        assert called_kw.get('check') is True
+        assert 'input' in called_kw
+        assert 'stdout' in called_kw
+        assert 'stderr' in called_kw
+        assert str(called_kw.get('cwd')) == '/tmp/scratch/output'
+        assert called_kw['input'].decode('utf-8').find(' --measures_only') == -1
 
         # Measures only run
         mock_subprocess.reset_mock()
@@ -74,14 +74,14 @@ def test_hpc_run_building(mock_subprocess, monkeypatch, basic_residential_projec
         monkeypatch.setenv('MEASURESONLY', '1')
         EagleBatch.run_building(*run_bldg_args)
         mock_subprocess.run.assert_called_once()
-        assert(mock_subprocess.run.call_args[0][0] == expected_singularity_args)
+        assert mock_subprocess.run.call_args[0][0] == expected_singularity_args
         called_kw = mock_subprocess.run.call_args[1]
-        assert(called_kw.get('check') is True)
-        assert('input' in called_kw)
-        assert('stdout' in called_kw)
-        assert('stderr' in called_kw)
-        assert(str(called_kw.get('cwd')) == '/tmp/scratch/output')
-        assert(called_kw['input'].decode('utf-8').find(' --measures_only') > -1)
+        assert called_kw.get('check') is True
+        assert 'input' in called_kw
+        assert 'stdout' in called_kw
+        assert 'stderr' in called_kw
+        assert str(called_kw.get('cwd')) == '/tmp/scratch/output'
+        assert called_kw['input'].decode('utf-8').find(' --measures_only') > -1
 
 
 def test_singularity_image_download_url(basic_residential_project_file):

--- a/buildstockbatch/test/test_validation.py
+++ b/buildstockbatch/test/test_validation.py
@@ -34,27 +34,27 @@ def filter_logs(logs, level):
 
 
 def test_base_validation_is_static():
-    assert(isinstance(BuildStockBatchBase.validate_project, types.FunctionType))
+    assert isinstance(BuildStockBatchBase.validate_project, types.FunctionType)
 
 
 def test_base_schema_validation_is_static():
-    assert(isinstance(BuildStockBatchBase.validate_project_schema, types.FunctionType))
+    assert isinstance(BuildStockBatchBase.validate_project_schema, types.FunctionType)
 
 
 def test_eagle_validation_is_static():
-    assert(isinstance(EagleBatch.validate_project, types.FunctionType))
+    assert isinstance(EagleBatch.validate_project, types.FunctionType)
 
 
 def test_local_docker_validation_is_static():
-    assert(isinstance(LocalDockerBatch.validate_project, types.FunctionType))
+    assert isinstance(LocalDockerBatch.validate_project, types.FunctionType)
 
 
 def test_complete_schema_passes_validation():
-    assert(BuildStockBatchBase.validate_project_schema(os.path.join(example_yml_dir, 'complete-schema.yml')))
+    assert BuildStockBatchBase.validate_project_schema(os.path.join(example_yml_dir, 'complete-schema.yml'))
 
 
 def test_minimal_schema_passes_validation():
-    assert(BuildStockBatchBase.validate_project_schema(os.path.join(example_yml_dir, 'minimal-schema.yml')))
+    assert BuildStockBatchBase.validate_project_schema(os.path.join(example_yml_dir, 'minimal-schema.yml'))
 
 
 @pytest.mark.parametrize("project_file", [
@@ -79,7 +79,7 @@ def test_xor_violations_fail(project_file, expected):
             with pytest.raises(expected):
                 BuildStockBatchBase.validate_xor_nor_schema_keys(project_file)
         else:
-            assert(BuildStockBatchBase.validate_xor_nor_schema_keys(project_file))
+            assert BuildStockBatchBase.validate_xor_nor_schema_keys(project_file)
 
 
 @pytest.mark.parametrize("project_file,expected", [
@@ -99,7 +99,7 @@ def test_validation_integration(project_file, expected):
             with pytest.raises(expected):
                 BuildStockBatchBase.validate_project(project_file)
         else:
-            assert(BuildStockBatchBase.validate_project(project_file))
+            assert BuildStockBatchBase.validate_project(project_file)
 
 
 @pytest.mark.parametrize("project_file", [

--- a/buildstockbatch/workflow_generator/test_workflow_generator.py
+++ b/buildstockbatch/workflow_generator/test_workflow_generator.py
@@ -8,22 +8,22 @@ import pytest
 def test_apply_logic_recursion():
 
     apply_logic = WorkflowGeneratorBase.make_apply_logic_arg(['one', 'two', 'three'])
-    assert(apply_logic == '(one&&two&&three)')
+    assert apply_logic == '(one&&two&&three)'
 
     apply_logic = WorkflowGeneratorBase.make_apply_logic_arg({
         'and': ['one', 'two', 'three']
     })
-    assert(apply_logic == '(one&&two&&three)')
+    assert apply_logic == '(one&&two&&three)'
 
     apply_logic = WorkflowGeneratorBase.make_apply_logic_arg({
         'or': ['four', 'five', 'six']
     })
-    assert(apply_logic == '(four||five||six)')
+    assert apply_logic == '(four||five||six)'
 
     apply_logic = WorkflowGeneratorBase.make_apply_logic_arg({
         'not': 'seven'
     })
-    assert(apply_logic == '!seven')
+    assert apply_logic == '!seven'
 
     apply_logic = WorkflowGeneratorBase.make_apply_logic_arg({
         'and': [
@@ -36,7 +36,7 @@ def test_apply_logic_recursion():
             'mno'
         ]
     })
-    assert(apply_logic == '(!abc&&(def||ghi)&&jkl&&mno)')
+    assert apply_logic == '(!abc&&(def||ghi)&&jkl&&mno)'
 
 
 def test_residential_package_apply(mocker):
@@ -76,9 +76,9 @@ def test_residential_package_apply(mocker):
     osw_gen = ResidentialDefaultWorkflowGenerator(cfg, 10)
     osw = osw_gen.create_osw(sim_id, building_id, upgrade_idx)
     upg_step = osw['steps'][2]
-    assert(upg_step['measure_dir_name'] == 'ApplyUpgrade')
-    assert(upg_step['arguments']['option_1'] == cfg['upgrades'][0]['options'][0]['option'])
-    assert(upg_step['arguments']['package_apply_logic'] == WorkflowGeneratorBase.make_apply_logic_arg(cfg['upgrades'][0]['package_apply_logic']))  # noqa E501
+    assert upg_step['measure_dir_name'] == 'ApplyUpgrade'
+    assert upg_step['arguments']['option_1'] == cfg['upgrades'][0]['options'][0]['option']
+    assert upg_step['arguments']['package_apply_logic'] == WorkflowGeneratorBase.make_apply_logic_arg(cfg['upgrades'][0]['package_apply_logic'])  # noqa E501
 
 
 def test_residential_simulation_controls_config(mocker):
@@ -99,7 +99,7 @@ def test_residential_simulation_controls_config(mocker):
     osw_gen = ResidentialDefaultWorkflowGenerator(cfg, n_datapoints)
     osw = osw_gen.create_osw(sim_id, building_id, upgrade_idx)
     step0 = osw['steps'][0]
-    assert(step0['measure_dir_name'] == 'ResidentialSimulationControls')
+    assert step0['measure_dir_name'] == 'ResidentialSimulationControls'
     default_args = {
         'timesteps_per_hr': 6,
         'begin_month': 1,
@@ -109,7 +109,7 @@ def test_residential_simulation_controls_config(mocker):
         'calendar_year': 2007
     }
     for k, v in default_args.items():
-        assert(step0['arguments'][k] == v)
+        assert step0['arguments'][k] == v
     cfg['workflow_generator']['args']['residential_simulation_controls'] = {
         'timesteps_per_hr': 2,
         'begin_month': 7
@@ -117,10 +117,10 @@ def test_residential_simulation_controls_config(mocker):
     osw_gen = ResidentialDefaultWorkflowGenerator(cfg, n_datapoints)
     osw = osw_gen.create_osw(sim_id, building_id, upgrade_idx)
     args = osw['steps'][0]['arguments']
-    assert(args['timesteps_per_hr'] == 2)
-    assert(args['begin_month'] == 7)
+    assert args['timesteps_per_hr'] == 2
+    assert args['begin_month'] == 7
     for argname in ('begin_day_of_month', 'end_month', 'end_day_of_month', 'calendar_year'):
-        assert(args[argname] == default_args[argname])
+        assert args[argname] == default_args[argname]
 
 
 def test_residential_simulation_weight(mocker):
@@ -139,7 +139,7 @@ def test_residential_simulation_weight(mocker):
     upgrade_idx = None
     osw_gen = ResidentialDefaultWorkflowGenerator(cfg, n_datapoints)
     osw = osw_gen.create_osw(sim_id, building_id, upgrade_idx)
-    assert(osw['steps'][1]['arguments']['sample_weight'] == pytest.approx(100, abs=1e-6))
+    assert osw['steps'][1]['arguments']['sample_weight'] == pytest.approx(100, abs=1e-6)
 
 
 def test_timeseries_csv_export(mocker):
@@ -165,7 +165,7 @@ def test_timeseries_csv_export(mocker):
     osw_gen = ResidentialDefaultWorkflowGenerator(cfg, n_datapoints)
     osw = osw_gen.create_osw(sim_id, building_id, upgrade_idx)
     timeseries_step = osw['steps'][-2]
-    assert(timeseries_step['measure_dir_name'] == 'TimeseriesCSVExport')
+    assert timeseries_step['measure_dir_name'] == 'TimeseriesCSVExport'
     default_args = {
         'reporting_frequency': 'Hourly',
         'include_enduse_subcategories': False,
@@ -174,10 +174,10 @@ def test_timeseries_csv_export(mocker):
     osw_gen = ResidentialDefaultWorkflowGenerator(cfg, n_datapoints)
     osw = osw_gen.create_osw(sim_id, building_id, upgrade_idx)
     args = osw['steps'][-2]['arguments']
-    assert(args['reporting_frequency'] == 'Timestep')
-    assert(args['output_variables'] == 'Zone Mean Air Temperature')
+    assert args['reporting_frequency'] == 'Timestep'
+    assert args['output_variables'] == 'Zone Mean Air Temperature'
     for argname in ('include_enduse_subcategories',):
-        assert(args[argname] == default_args[argname])
+        assert args[argname] == default_args[argname]
 
 
 def test_additional_reporting_measures(mocker):
@@ -203,15 +203,15 @@ def test_additional_reporting_measures(mocker):
     osw_gen = ResidentialDefaultWorkflowGenerator(cfg, 10)
     osw = osw_gen.create_osw(sim_id, building_id, upgrade_idx)
     reporting_measure_1_step = osw['steps'][-3]
-    assert(reporting_measure_1_step['measure_dir_name'] == 'ReportingMeasure1')
-    assert(reporting_measure_1_step['arguments'] == {})
-    assert(reporting_measure_1_step['measure_type'] == 'ReportingMeasure')
+    assert reporting_measure_1_step['measure_dir_name'] == 'ReportingMeasure1'
+    assert reporting_measure_1_step['arguments'] == {}
+    assert reporting_measure_1_step['measure_type'] == 'ReportingMeasure'
     reporting_measure_2_step = osw['steps'][-2]
-    assert(reporting_measure_2_step['measure_dir_name'] == 'ReportingMeasure2')
-    assert(reporting_measure_2_step['arguments']['arg1'] == 'asdf')
-    assert(reporting_measure_2_step['arguments']['arg2'] == 'jkl')
-    assert(len(reporting_measure_2_step['arguments']))
-    assert(reporting_measure_2_step['measure_type'] == 'ReportingMeasure')
+    assert reporting_measure_2_step['measure_dir_name'] == 'ReportingMeasure2'
+    assert reporting_measure_2_step['arguments']['arg1'] == 'asdf'
+    assert reporting_measure_2_step['arguments']['arg2'] == 'jkl'
+    assert len(reporting_measure_2_step['arguments'])
+    assert reporting_measure_2_step['measure_type'] == 'ReportingMeasure'
 
 
 def test_ignore_measures_argument(mocker):
@@ -278,10 +278,10 @@ def test_default_apply_upgrade(mocker):
     for step in osw['steps']:
         if step['measure_dir_name'] == 'ApplyUpgrade':
             break
-    assert(step['measure_dir_name'] == 'ApplyUpgrade')
-    assert(len(step['arguments']) == 2)
-    assert(step['arguments']['run_measure'] == 1)
-    assert(step['arguments']['option_1'] == 'Parameter|Option')
+    assert step['measure_dir_name'] == 'ApplyUpgrade'
+    assert len(step['arguments']) == 2
+    assert step['arguments']['run_measure'] == 1
+    assert step['arguments']['option_1'] == 'Parameter|Option'
 
 
 def test_simulation_output(mocker):
@@ -306,7 +306,7 @@ def test_simulation_output(mocker):
     osw_gen = ResidentialDefaultWorkflowGenerator(cfg, n_datapoints)
     osw = osw_gen.create_osw(sim_id, building_id, upgrade_idx)
     simulation_output_step = osw['steps'][-2]
-    assert(simulation_output_step['measure_dir_name'] == 'SimulationOutputReport')
+    assert simulation_output_step['measure_dir_name'] == 'SimulationOutputReport'
     default_args = {
         'include_enduse_subcategories': False
     }
@@ -314,7 +314,7 @@ def test_simulation_output(mocker):
     osw = osw_gen.create_osw(sim_id, building_id, upgrade_idx)
     args = osw['steps'][-2]['arguments']
     for argname in ('include_enduse_subcategories',):
-        assert(args[argname] != default_args[argname])
+        assert args[argname] != default_args[argname]
 
 
 def test_residential_hpxml(mocker):
@@ -359,45 +359,45 @@ def test_residential_hpxml(mocker):
     osw = osw_gen.create_osw(sim_id, building_id, upgrade_idx)
 
     steps = osw['steps']
-    assert(len(steps) == 6)
+    assert len(steps) == 6
 
     build_existing_model_step = steps[0]
-    assert(build_existing_model_step['measure_dir_name'] == 'BuildExistingModel')
-    assert(build_existing_model_step['arguments']['simulation_control_run_period_begin_month'] == 2)
-    assert(build_existing_model_step['arguments']['simulation_control_run_period_begin_day_of_month'] == 1)
-    assert(build_existing_model_step['arguments']['simulation_control_run_period_end_month'] == 2)
-    assert(build_existing_model_step['arguments']['simulation_control_run_period_end_day_of_month'] == 28)
-    assert(build_existing_model_step['arguments']['simulation_control_run_period_calendar_year'] == 2010)
+    assert build_existing_model_step['measure_dir_name'] == 'BuildExistingModel'
+    assert build_existing_model_step['arguments']['simulation_control_run_period_begin_month'] == 2
+    assert build_existing_model_step['arguments']['simulation_control_run_period_begin_day_of_month'] == 1
+    assert build_existing_model_step['arguments']['simulation_control_run_period_end_month'] == 2
+    assert build_existing_model_step['arguments']['simulation_control_run_period_end_day_of_month'] == 28
+    assert build_existing_model_step['arguments']['simulation_control_run_period_calendar_year'] == 2010
 
     apply_upgrade_step = steps[1]
-    assert(apply_upgrade_step['measure_dir_name'] == 'ApplyUpgrade')
+    assert apply_upgrade_step['measure_dir_name'] == 'ApplyUpgrade'
 
     simulation_output_step = steps[2]
-    assert(simulation_output_step['measure_dir_name'] == 'ReportSimulationOutput')
-    assert(simulation_output_step['arguments']['timeseries_frequency'] == 'hourly')
-    assert(simulation_output_step['arguments']['include_timeseries_total_consumptions'] is True)
-    assert(simulation_output_step['arguments']['include_timeseries_fuel_consumptions'] is False)
-    assert(simulation_output_step['arguments']['include_timeseries_end_use_consumptions'] is True)
-    assert(simulation_output_step['arguments']['include_timeseries_emissions'] is False)
-    assert(simulation_output_step['arguments']['include_timeseries_emission_fuels'] is False)
-    assert(simulation_output_step['arguments']['include_timeseries_emission_end_uses'] is False)
-    assert(simulation_output_step['arguments']['include_timeseries_hot_water_uses'] is False)
-    assert(simulation_output_step['arguments']['include_timeseries_total_loads'] is True)
-    assert(simulation_output_step['arguments']['include_timeseries_component_loads'] is False)
-    assert(simulation_output_step['arguments']['include_timeseries_zone_temperatures'] is False)
-    assert(simulation_output_step['arguments']['include_timeseries_airflows'] is False)
-    assert(simulation_output_step['arguments']['include_timeseries_weather'] is False)
-    assert(simulation_output_step['arguments']['add_timeseries_dst_column'] is True)
-    assert(simulation_output_step['arguments']['add_timeseries_utc_column'] is True)
+    assert simulation_output_step['measure_dir_name'] == 'ReportSimulationOutput'
+    assert simulation_output_step['arguments']['timeseries_frequency'] == 'hourly'
+    assert simulation_output_step['arguments']['include_timeseries_total_consumptions'] is True
+    assert simulation_output_step['arguments']['include_timeseries_fuel_consumptions'] is False
+    assert simulation_output_step['arguments']['include_timeseries_end_use_consumptions'] is True
+    assert simulation_output_step['arguments']['include_timeseries_emissions'] is False
+    assert simulation_output_step['arguments']['include_timeseries_emission_fuels'] is False
+    assert simulation_output_step['arguments']['include_timeseries_emission_end_uses'] is False
+    assert simulation_output_step['arguments']['include_timeseries_hot_water_uses'] is False
+    assert simulation_output_step['arguments']['include_timeseries_total_loads'] is True
+    assert simulation_output_step['arguments']['include_timeseries_component_loads'] is False
+    assert simulation_output_step['arguments']['include_timeseries_zone_temperatures'] is False
+    assert simulation_output_step['arguments']['include_timeseries_airflows'] is False
+    assert simulation_output_step['arguments']['include_timeseries_weather'] is False
+    assert simulation_output_step['arguments']['add_timeseries_dst_column'] is True
+    assert simulation_output_step['arguments']['add_timeseries_utc_column'] is True
 
     hpxml_output_step = steps[3]
-    assert(hpxml_output_step['measure_dir_name'] == 'ReportHPXMLOutput')
+    assert hpxml_output_step['measure_dir_name'] == 'ReportHPXMLOutput'
 
     upgrade_costs_step = steps[4]
-    assert(upgrade_costs_step['measure_dir_name'] == 'UpgradeCosts')
+    assert upgrade_costs_step['measure_dir_name'] == 'UpgradeCosts'
 
     server_dir_cleanup_step = steps[5]
-    assert(server_dir_cleanup_step['measure_dir_name'] == 'ServerDirectoryCleanup')
+    assert server_dir_cleanup_step['measure_dir_name'] == 'ServerDirectoryCleanup'
 
 
 def test_com_default_workflow_generator(mocker):
@@ -423,12 +423,12 @@ def test_com_default_workflow_generator(mocker):
     osw_gen = CommercialDefaultWorkflowGenerator(cfg, 10)
     osw = osw_gen.create_osw(sim_id, building_id, upgrade_idx)
     reporting_measure_1_step = osw['steps'][-2]
-    assert(reporting_measure_1_step['measure_dir_name'] == 'ReportingMeasure1')
-    assert(reporting_measure_1_step['arguments'] == {})
-    assert(reporting_measure_1_step['measure_type'] == 'ReportingMeasure')
+    assert reporting_measure_1_step['measure_dir_name'] == 'ReportingMeasure1'
+    assert reporting_measure_1_step['arguments'] == {}
+    assert reporting_measure_1_step['measure_type'] == 'ReportingMeasure'
     reporting_measure_2_step = osw['steps'][-1]
-    assert(reporting_measure_2_step['measure_dir_name'] == 'ReportingMeasure2')
-    assert(reporting_measure_2_step['arguments']['arg1'] == 'asdf')
-    assert(reporting_measure_2_step['arguments']['arg2'] == 'jkl')
-    assert(len(reporting_measure_2_step['arguments']))
-    assert(reporting_measure_2_step['measure_type'] == 'ReportingMeasure')
+    assert reporting_measure_2_step['measure_dir_name'] == 'ReportingMeasure2'
+    assert reporting_measure_2_step['arguments']['arg1'] == 'asdf'
+    assert reporting_measure_2_step['arguments']['arg2'] == 'jkl'
+    assert len(reporting_measure_2_step['arguments'])
+    assert reporting_measure_2_step['measure_type'] == 'ReportingMeasure'

--- a/create_eagle_env.sh
+++ b/create_eagle_env.sh
@@ -26,7 +26,7 @@ MY_CONDA_PREFIX="$CONDA_ENVS_DIR/$MY_CONDA_ENV_NAME"
 echo "Creating $MY_CONDA_PREFIX"
 module load conda
 conda remove -y --prefix "$MY_CONDA_PREFIX" --all
-conda create -y --prefix "$MY_CONDA_PREFIX" -c conda-forge "pyarrow>=7.0.0" python=3.7.8 "numpy>=1.20.0" "pandas>=1.0.0,!=1.0.4" "dask>=2021.5" "distributed>=2021.5" ruby
+conda create -y --prefix "$MY_CONDA_PREFIX" -c conda-forge "pyarrow>=7.0.0" "python=3.9" "numpy>=1.20.0" "pandas>=1.0.0,!=1.0.4" "dask>=2021.5" "distributed>=2021.5" ruby
 source deactivate 
 source activate "$MY_CONDA_PREFIX"
 which pip

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -68,3 +68,9 @@ Development Changelog
 
         Add basic logic validation that checks for incorrect use of 'and' and 'not' block.
         BSB requires at least python 3.8.
+
+    .. change::
+        :tags: general, feature, eagle
+        :pullreq: 304
+
+        Added ability to resubmit failed array jobs on Eagle. 

--- a/docs/run_sims.rst
+++ b/docs/run_sims.rst
@@ -64,7 +64,18 @@ Next, you will need to add an ``eagle`` top level key to the project file, which
 
 In general, be conservative on the time estimates. It can be helpful to run a small batch with
 pretty conservative estimates and then look at the output logs to see how long things really took
-before submitting a full batch simulation. 
+before submitting a full batch simulation.
+
+Re-running failed array jobs on Eagle
+.....................................
+
+Running buildstockbatch on Eagle breaks the simulation into an array of jobs
+that you set with the ``eagle.n_jobs`` configuration parameter. Each of those
+jobs runs a batch of simulations on a single compute node. Sometimes a handful
+of jobs will fail due to issues with Eagle (filesystem or timeouts). If most of
+the jobs succeeded, rather than rerun everything you can resubmit just the jobs
+that failed with the ``--rerun_failed`` command line argument. This will also
+clear out and rerun the postprocessing. 
 
 
 Amazon Web Services


### PR DESCRIPTION
## Pull Request Description

Eagle is having intermittent problems where jobs will fail due to weird filesystem issues. Usually it's just a handful of the jobs. This makes it so we can just rerun those handful and not have to resubmit the whole thing. 

### Still to do

- [x] Add a "everything finished fine" message to the end of the job output and rerun only those missing that instead of ones with a "Traceback" in them. Less potentially problematic.
- [x] Have the postprocessing check that all the jobs ran successfully before gathering results and give an informative error message if not.

## Checklist

Not all may apply

- [x] Code changes (must work)
- [x] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [x] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/ci.yml` as necessary.
- [x] All other unit tests passing
- [x] Update validation for project config yaml file changes
- [x] Update existing documentation
- [x] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
- [x] Add to the changelog_dev.rst file and propose migration text in the pull request
