### PR TITLE
Rerun if job.out is missing

### DIFF
--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -86,3 +86,10 @@ Development Changelog
         :pullreq: 303
 
         Add ability to calculate simple utility bills using the ``residential_hpxml`` workflow.
+
+    .. change::
+        :tags: general, feature, eagle
+        :pullreq: 306
+        :tickets: 305
+
+        Now reruns jobs where the job.out-x is missing entirely.


### PR DESCRIPTION
Fixes #305.

## Pull Request Description

Now reruns a job if the job.out-x is missing entirely.

## Checklist

Not all may apply

- [x] Code changes (must work)
- [x] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [x] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/ci.yml` as necessary.
- [ ] All other unit tests passing
- [x] ~~Update validation for project config yaml file changes~~
- [x] ~~Update existing documentation~~
- [x] ~~run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)~~
- [x] Add to the changelog_dev.rst file and propose migration text in the pull request
