### PR TITLE
Automatically add the ResStock Development project to PRs and Issues

### DIFF
--- a/.github/workflows/add_to_project.yml
+++ b/.github/workflows/add_to_project.yml
@@ -1,0 +1,21 @@
+name: Add pull request or issue to project
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+  issues:
+    types:
+      - opened
+      - reopened
+      - transferred
+
+jobs:
+  add-to-project:
+    name: Add pull request or issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.3.0
+        with:
+          project-url: https://github.com/orgs/NREL/projects/38
+          github-token: ${{ secrets.GHB_TOKEN }}


### PR DESCRIPTION
## Pull Request Description

This is similar to these PRs:
- resstock-estimation [#270](https://github.com/NREL/resstock-estimation/pull/270)
- resstock [#993](https://github.com/NREL/resstock/pull/993)

Automatically adds Issues and Pull Requests to the "ResStock Development" project on the NREL organization project page.

NREL Organization Project: https://github.com/orgs/NREL/projects/38/

This PR worked as I did not add the project to the "ResStock Development" project and the "Add pull request or issue to project" check passed.

## Checklist

Not all may apply

- [ ] Code changes (must work)
- [x] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [ ] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/ci.yml` as necessary.
- [x] All other unit tests passing
- [ ] Update validation for project config yaml file changes
- [ ] Update existing documentation
- [ ] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
- [ ] Add to the changelog_dev.rst file and propose migration text in the pull request
