### PR TITLE
Dask Worker Bugfix

### DIFF
--- a/buildstockbatch/aws/s3_assets/setup_postprocessing.py
+++ b/buildstockbatch/aws/s3_assets/setup_postprocessing.py
@@ -6,7 +6,7 @@ setup(
     description='Just the stand alone postprocessing functions from Buildstock-Batch',
     py_modules=['postprocessing'],
     install_requires=[
-        'dask[complete]>=2021.5',
+        'dask[complete]>=2022.10.0',
         's3fs>=0.4.2,<0.5.0',
         'boto3',
         'pandas>=1.0.0,!=1.0.4',

--- a/buildstockbatch/eagle_postprocessing.sh
+++ b/buildstockbatch/eagle_postprocessing.sh
@@ -26,7 +26,7 @@ echo $SLURM_JOB_NODELIST_PACK_GROUP_1
 pdsh -w $SLURM_JOB_NODELIST_PACK_GROUP_1 "free -h"
 pdsh -w $SLURM_JOB_NODELIST_PACK_GROUP_1 "df -i; df -h"
 
-$MY_CONDA_ENV/bin/dask-scheduler --scheduler-file $SCHEDULER_FILE &> $OUT_DIR/dask_scheduler.out &
+$MY_CONDA_ENV/bin/dask scheduler --scheduler-file $SCHEDULER_FILE &> $OUT_DIR/dask_scheduler.out &
 pdsh -w $SLURM_JOB_NODELIST_PACK_GROUP_1 "$MY_CONDA_ENV/bin/dask worker --scheduler-file $SCHEDULER_FILE --local-directory /tmp/scratch/dask --nworkers ${NPROCS} --nthreads 1 --memory-limit ${MEMORY}MB" &> $OUT_DIR/dask_workers.out &
 
 time python -u -m buildstockbatch.eagle "$PROJECTFILE"

--- a/buildstockbatch/eagle_postprocessing.sh
+++ b/buildstockbatch/eagle_postprocessing.sh
@@ -27,6 +27,6 @@ pdsh -w $SLURM_JOB_NODELIST_PACK_GROUP_1 "free -h"
 pdsh -w $SLURM_JOB_NODELIST_PACK_GROUP_1 "df -i; df -h"
 
 $MY_CONDA_ENV/bin/dask-scheduler --scheduler-file $SCHEDULER_FILE &> $OUT_DIR/dask_scheduler.out &
-pdsh -w $SLURM_JOB_NODELIST_PACK_GROUP_1 "$MY_CONDA_ENV/bin/dask-worker --scheduler-file $SCHEDULER_FILE --local-directory /tmp/scratch/dask --nprocs ${NPROCS} --nthreads 1 --memory-limit ${MEMORY}MB" &> $OUT_DIR/dask_workers.out &
+pdsh -w $SLURM_JOB_NODELIST_PACK_GROUP_1 "$MY_CONDA_ENV/bin/dask worker --scheduler-file $SCHEDULER_FILE --local-directory /tmp/scratch/dask --nworkers ${NPROCS} --nthreads 1 --memory-limit ${MEMORY}MB" &> $OUT_DIR/dask_workers.out &
 
 time python -u -m buildstockbatch.eagle "$PROJECTFILE"

--- a/create_eagle_env.sh
+++ b/create_eagle_env.sh
@@ -26,7 +26,7 @@ MY_CONDA_PREFIX="$CONDA_ENVS_DIR/$MY_CONDA_ENV_NAME"
 echo "Creating $MY_CONDA_PREFIX"
 module load conda
 conda remove -y --prefix "$MY_CONDA_PREFIX" --all
-conda create -y --prefix "$MY_CONDA_PREFIX" -c conda-forge "pyarrow>=7.0.0" "python=3.9" "numpy>=1.20.0" "pandas>=1.0.0,!=1.0.4" "dask>=2021.5" "distributed>=2021.5" ruby
+conda create -y --prefix "$MY_CONDA_PREFIX" -c conda-forge "pyarrow>=7.0.0" "python=3.9" "numpy>=1.20.0" "pandas>=1.0.0,!=1.0.4" "dask>=2022.10.0" "distributed>=2021.5" ruby
 source deactivate 
 source activate "$MY_CONDA_PREFIX"
 which pip

--- a/docs/changelog/changelog_2022_10_0.rst
+++ b/docs/changelog/changelog_2022_10_0.rst
@@ -100,3 +100,9 @@ v2022.10.0 Changelog
         where a new timeseries_csv_export key was added to the workflow schema in order to trigger timeseries postprocessing.
         Changes the CLI commands to work with OpenStudio 3.X when custom_gems=True.
         Enables use of custom gems in local docker runs by installing to local docker volume.
+
+    .. change::
+        :tags: bugfix, eagle
+        :pullreq: 324
+
+        Using new style CLI for dask scheduler and dask workers. Requiring dask >= 2022.10.

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setuptools.setup(
         'pandas>=1.0.0,!=1.0.4',
         'joblib',
         'pyarrow>=3.0.0',
-        'dask[complete]>=2022.2.0',
+        'dask[complete]>=2022.10.0',
         'docker',
         'boto3>=1.10.44',
         's3fs>=0.4.0,<0.5.0',


### PR DESCRIPTION
## Pull Request Description

In some [recent changes](https://distributed.dask.org/en/stable/changelog.html#v2022-10-0) to the dask worker cli, an option we were using, `--nprocs`, was replaced. The change made it so the workers never started on Eagle for postprocessing. This switches things over to the new style and requires the new dask version.

## Checklist

Not all may apply

- [x] Code changes (must work)
- [x] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [x] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/ci.yml` as necessary.
- [x] All other unit tests passing
- [x] Update validation for project config yaml file changes
- [x] Update existing documentation
- [x] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
- [x] Add to the changelog_dev.rst file and propose migration text in the pull request
