### PR TITLE
adding validation of the number of options in the ApplyUpgrade measure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,4 +79,4 @@ jobs:
         if: ${{ matrix.python-version == '3.10' }}
         with:
           name: documentation
-          path: docs/_build/html/
+          path: buildstockbatch/docs/_build/html/

--- a/buildstockbatch/base.py
+++ b/buildstockbatch/base.py
@@ -14,8 +14,10 @@ from dask.distributed import Client
 import difflib
 from fsspec.implementations.local import LocalFileSystem
 import logging
+from lxml import objectify
 import os
 import pandas as pd
+import re
 import requests
 import shutil
 import tempfile
@@ -261,6 +263,7 @@ class BuildStockBatchBase(object):
         assert BuildStockBatchBase.validate_postprocessing_spec(project_file)
         assert BuildStockBatchBase.validate_resstock_or_comstock_version(project_file)
         assert BuildStockBatchBase.validate_openstudio_version(project_file)
+        assert BuildStockBatchBase.validate_number_of_options(project_file)
         logger.info('Base Validation Successful')
         return True
 
@@ -699,6 +702,57 @@ class BuildStockBatchBase(object):
                 val_err = f"BuildStockBatch version {BuildStockBatch_Version} or above is required" \
                     f" for ResStock or ComStock version {stock_version}. Found {bsb_version}"
                 raise ValidationError(val_err)
+
+        return True
+
+    @staticmethod
+    def validate_number_of_options(project_file):
+        """Checks that there aren't more options than are allowed in the ApplyUpgrade measure.
+
+        :param project_file: path to project file
+        :type project_file: str
+        :raises ValidationError: if there are more options defined than there are in the measure.
+        :return: whether validation passes or not
+        :rtype: bool
+        """
+        cfg = get_project_configuration(project_file)
+        measure_xml_filename = os.path.join(
+            cfg["buildstock_directory"], "measures", "ApplyUpgrade", "measure.xml"
+        )
+        if os.path.exists(measure_xml_filename):
+            measure_xml_tree = objectify.parse(measure_xml_filename)
+            measure_xml = measure_xml_tree.getroot()
+            n_options_in_measure = 0
+            n_costs_per_option_in_measure = 0
+            for argument in measure_xml.arguments.argument:
+                m_option = re.match(r"^option_(\d+)$", str(argument.name))
+                if m_option:
+                    option_number = int(m_option.group(1))
+                    n_options_in_measure = max(option_number, n_options_in_measure)
+                m_costs = re.match(r"^option_(\d+)_cost_(\d+)_value", str(argument.name))
+                if m_costs:
+                    cost_number = int(m_costs.group(2))
+                    n_costs_per_option_in_measure = max(cost_number, n_costs_per_option_in_measure)
+            n_options_in_cfg = 0
+            n_costs_in_cfg = 0
+            for upgrade in cfg.get("upgrades", []):
+                options = upgrade.get("options", [])
+                n_options = len(options)
+                n_costs = max(len(option.get("costs", [])) for option in options)
+                n_options_in_cfg = max(n_options, n_options_in_cfg)
+                n_costs_in_cfg = max(n_costs, n_costs_in_cfg)
+            err_msgs = []
+            if n_options_in_cfg > n_options_in_measure:
+                err_msgs.append(
+                    f"There are {n_options_in_cfg} options in an upgrade in your project file and only {n_options_in_measure} in the ApplyUpgrade measure."
+                )
+            if n_costs_in_cfg > n_costs_per_option_in_measure:
+                err_msgs.append(
+                    f"There are {n_costs_in_cfg} costs on an option in your project file and only {n_costs_per_option_in_measure} in the ApplyUpgrade measure."
+                )
+            if err_msgs:
+                err_msgs.append("See https://github.com/NREL/buildstockbatch/wiki/Adding-Options-to-the-ApplyUpgrade-measure")
+                raise ValidationError("\n".join(err_msgs))
 
         return True
 

--- a/buildstockbatch/base.py
+++ b/buildstockbatch/base.py
@@ -744,14 +744,18 @@ class BuildStockBatchBase(object):
             err_msgs = []
             if n_options_in_cfg > n_options_in_measure:
                 err_msgs.append(
-                    f"There are {n_options_in_cfg} options in an upgrade in your project file and only {n_options_in_measure} in the ApplyUpgrade measure."
+                    f"There are {n_options_in_cfg} options in an upgrade in your project file and only "
+                    f"{n_options_in_measure} in the ApplyUpgrade measure."
                 )
             if n_costs_in_cfg > n_costs_per_option_in_measure:
                 err_msgs.append(
-                    f"There are {n_costs_in_cfg} costs on an option in your project file and only {n_costs_per_option_in_measure} in the ApplyUpgrade measure."
+                    f"There are {n_costs_in_cfg} costs on an option in your project file and only "
+                    f"{n_costs_per_option_in_measure} in the ApplyUpgrade measure."
                 )
             if err_msgs:
-                err_msgs.append("See https://github.com/NREL/buildstockbatch/wiki/Adding-Options-to-the-ApplyUpgrade-measure")
+                err_msgs.append(
+                    "See https://github.com/NREL/buildstockbatch/wiki/Adding-Options-to-the-ApplyUpgrade-measure"
+                )
                 raise ValidationError("\n".join(err_msgs))
 
         return True

--- a/buildstockbatch/localdocker.py
+++ b/buildstockbatch/localdocker.py
@@ -13,6 +13,7 @@ This object contains the code required for execution of local docker batch simul
 import argparse
 from dask.distributed import Client, LocalCluster
 import docker
+from docker.errors import ImageNotFound
 import functools
 from fsspec.implementations.local import LocalFileSystem
 import gzip
@@ -66,8 +67,11 @@ class LocalDockerBatch(DockerBatchBase):
 
     def __init__(self, project_filename):
         super().__init__(project_filename)
-        logger.debug(f'Pulling docker image: {self.docker_image}')
-        self.docker_client.images.pull(self.docker_image)
+        try:
+            self.docker_client.images.get(self.docker_image)
+        except ImageNotFound:
+            logger.debug(f'Pulling docker image: {self.docker_image}')
+            self.docker_client.images.pull(self.docker_image)
 
         # Create simulation_output dir
         sim_out_ts_dir = os.path.join(self.results_dir, 'simulation_output', 'timeseries')

--- a/buildstockbatch/test/test_integration.py
+++ b/buildstockbatch/test/test_integration.py
@@ -5,7 +5,6 @@ import pytest
 import shutil
 import tempfile
 import json
-import re
 
 from buildstockbatch.localdocker import LocalDockerBatch
 from buildstockbatch.utils import get_project_configuration

--- a/buildstockbatch/test/test_integration.py
+++ b/buildstockbatch/test/test_integration.py
@@ -3,8 +3,13 @@ import pandas as pd
 import pathlib
 import pytest
 import shutil
+import tempfile
+import json
+import re
 
 from buildstockbatch.localdocker import LocalDockerBatch
+from buildstockbatch.utils import get_project_configuration
+from buildstockbatch.exc import ValidationError
 
 resstock_directory = pathlib.Path(
     os.environ.get("RESSTOCK_DIR", pathlib.Path(__file__).resolve().parent.parent.parent.parent / "resstock")
@@ -22,7 +27,7 @@ resstock_required = pytest.mark.skipif(
     resstock_directory / "project_testing" / "testing_upgrades.yml",
 ], ids=lambda x: x.stem)
 @resstock_required
-def test_resstock_local_batch(project_filename, mocker):
+def test_resstock_local_batch(project_filename):
     LocalDockerBatch.validate_project(str(project_filename))
     batch = LocalDockerBatch(str(project_filename))
 
@@ -81,3 +86,18 @@ def test_resstock_local_batch(project_filename, mocker):
     assert (ts_pq_path / "_metadata").exists()
 
     shutil.rmtree(out_path)
+
+
+@resstock_required
+def test_number_of_options_apply_upgrade():
+    proj_filename = resstock_directory / "project_national" / "national_upgrades.yml"
+    cfg = get_project_configuration(str(proj_filename))
+    cfg["upgrades"][-1]["options"] = cfg["upgrades"][-1]["options"] * 10
+    cfg["upgrades"][0]["options"][0]["costs"] = cfg["upgrades"][0]["options"][0]["costs"] * 5
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = pathlib.Path(tmpdir)
+        new_proj_filename = tmppath / "project.yml"
+        with open(new_proj_filename, "w") as f:
+            json.dump(cfg, f)
+        with pytest.raises(ValidationError):
+            LocalDockerBatch.validate_number_of_options(str(new_proj_filename))

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -26,3 +26,13 @@ Development Changelog
         :pullreq: 326
 
         Adds some integration tests with the lastest ResStock.
+
+    .. change::
+        :tags: validaton
+        :pullreq: 330
+        :tickets: 329
+
+        Adds a validation step to verify the ApplyUpgrade measure has enough
+        options specified to support the upgrades in the current project file.
+        Instructs the user how to add more options to the ApplyUpgrade measure
+        if not.

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -25,10 +25,10 @@ Development Changelog
         :tags: general
         :pullreq: 326
 
-        Adds some integration tests with the lastest ResStock.
+        Adds some integration tests with the latest ResStock.
 
     .. change::
-        :tags: validaton
+        :tags: validation
         :pullreq: 330
         :tickets: 329
 

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setuptools.setup(
         'yamale',
         'ruamel.yaml',
         'awsretry',
+        'lxml'
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
Fixes #329.

## Pull Request Description

This checks the ApplyUpgrade measure and throws an error message with a [link](https://github.com/NREL/buildstockbatch/wiki/Adding-Options-to-the-ApplyUpgrade-measure) explaining how to fix it if there are more options than the measure allows.

## Checklist

Not all may apply

- [x] Code changes (must work)
- [x] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [x] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/ci.yml` as necessary.
- [x] All other unit tests passing
- [x] ~~Update validation for project config yaml file changes~~
- [x] ~~Update existing documentation~~
- [x] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
- [x] Add to the changelog_dev.rst file and propose migration text in the pull request
