### PR TITLE
Sorting results by building_id

### DIFF
--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -446,7 +446,6 @@ def combine_results(fs, results_dir, cfg, do_timeseries=True):
             else:
                 logger.info(f"There are no timeseries files for upgrade {Path(upgrade_folder).name}.")
 
-    if do_timeseries:
         # Sort the columns
         all_ts_cols_sorted = ['building_id'] + sorted(x for x in all_ts_cols if x.startswith('time'))
         all_ts_cols.difference_update(all_ts_cols_sorted)
@@ -474,11 +473,11 @@ def combine_results(fs, results_dir, cfg, do_timeseries=True):
         logger.info(f"Processing upgrade {upgrade_id}. ")
         df = dask.compute(results_df_groups.get_group(upgrade_id))[0]
         logger.info(f"Obtained results_df for {upgrade_id} with {len(df)} datapoints. ")
-        df.sort_index(inplace=True)
         df.rename(columns=to_camelcase, inplace=True)
         df = clean_up_results_df(df, cfg, keep_upgrade_id=True)
         del df['upgrade']
         df.set_index('building_id', inplace=True)
+        df.sort_index(inplace=True)
         schema = None
         partition_df = df[df_partition_columns].copy()
         partition_df.rename(columns={df_c: c for df_c, c in zip(df_partition_columns, partition_columns)},

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -36,3 +36,10 @@ Development Changelog
         options specified to support the upgrades in the current project file.
         Instructs the user how to add more options to the ApplyUpgrade measure
         if not.
+
+    .. change::
+        :tags: bugfix
+        :pullreq: 332
+        :tickets: 331
+
+        Sort the results by ``building_id``.


### PR DESCRIPTION
Fixes #331.

## Pull Request Description

Sorts results by `building_id` in the results csvs and parquets.

I didn't add a specific test for this one because it only gets unsorted on Eagle, so I couldn't duplicate the problem locally. I did run a test run on Eagle to confirm that it works now, though.

## Checklist

Not all may apply

- [x] Code changes (must work)
- [x] ~~Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)~~
- [x] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/ci.yml` as necessary.
- [ ] All other unit tests passing
- [x] ~~Update validation for project config yaml file changes~~
- [x] ~~Update existing documentation~~
- [x] Run a small batch run to make sure it all works (local is fine, unless an Eagle specific feature)
- [x] Add to the changelog_dev.rst file and propose migration text in the pull request
