### PR TITLE
Skip validation from HPXMLtoOpenStudio

### DIFF
--- a/buildstockbatch/workflow_generator/residential_hpxml.py
+++ b/buildstockbatch/workflow_generator/residential_hpxml.py
@@ -403,7 +403,8 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
                     'hpxml_path': '../../run/home.xml',
                     'output_dir': '../../run',
                     'debug': debug,
-                    'add_component_loads': add_component_loads
+                    'add_component_loads': add_component_loads,
+                    'skip_validation': True
                 }
             }
         ])

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -21,3 +21,9 @@ Development Changelog
         :tickets: 300
 
         Remove docker dependency for local runs.
+
+    .. change::
+        :tags: workflow, feature
+        :pullreq: 353
+
+        Avoid unnecessarily validating the HPXML file twice after having slightly changed the ``residential_hpxml`` workflow.


### PR DESCRIPTION
Because we've changed the behavior of apply_defaults (to also apply validation) in BuildResidentialHPXML: https://github.com/NREL/OpenStudio-HPXML/pull/1298.