### PR TITLE
Force schedule columns to float

### DIFF
--- a/buildstockbatch/base.py
+++ b/buildstockbatch/base.py
@@ -17,6 +17,7 @@ import logging
 from lxml import objectify
 import os
 import pandas as pd
+import numpy as np
 import re
 import requests
 import shutil
@@ -215,7 +216,7 @@ class BuildStockBatchBase(object):
 
             tsdf = pd.read_csv(timeseries_filepath, parse_dates=actual_time_cols, skiprows=skiprows)
             if os.path.isfile(schedules_filepath):
-                schedules = pd.read_csv(schedules_filepath)
+                schedules = pd.read_csv(schedules_filepath, dtype=np.float64)
                 schedules.rename(columns=lambda x: f'schedules_{x}', inplace=True)
                 schedules['TimeDST'] = tsdf['Time']
                 tsdf = tsdf.merge(schedules, how='left', on='TimeDST')

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -21,3 +21,10 @@ Development Changelog
         :tickets: 300
 
         Remove docker dependency for local runs.
+
+    .. change::
+        :tags: general, bugfix
+        :pullreq: 355
+        :tickets: 352
+
+        Fix an issue with schedules datatype that was causing the crash of postporcessing at the final step.


### PR DESCRIPTION
Addresses #352

Sometimes a building's particular schedule column can have integer only values which results in pandas assigning integer datatype to that column. But this causes problem when generating the metadata during postprocessing since other schedule file can have float datatypes. This PR fixes the issue by always interpreting the schedule values as float during read.
