### PR TITLE
Add references section to yaml schema

### DIFF
--- a/buildstockbatch/schemas/v0.3.yaml
+++ b/buildstockbatch/schemas/v0.3.yaml
@@ -14,6 +14,7 @@ os_version: str(required=False)
 os_sha: str(required=False)
 upgrades: list(include('upgrade-spec'), required=False)
 postprocessing: include('postprocessing-spec', required=False)
+references: map(required=False)
 ---
 aws-spec:
   job_identifier: regex('^[a-zA-Z]\w{,9}$', required=True)

--- a/buildstockbatch/test/test_inputs/enforce-validate-measures-good-2-with-anchors.yml
+++ b/buildstockbatch/test/test_inputs/enforce-validate-measures-good-2-with-anchors.yml
@@ -1,0 +1,51 @@
+schema_version: '0.3'
+buildstock_directory: test_openstudio_buildstock
+project_directory: project_singlefamilydetached
+weather_files_url: https://fake-url
+baseline:
+  n_buildings_represented: 81221016
+
+sampler:
+  type: residential_quota
+  args:
+    n_datapoints: 30
+
+workflow_generator:
+  type: residential_default
+  args:
+    simulation_output:
+      include_enduse_subcategories: true
+    timeseries_csv_export:
+      reporting_frequency: Timestep
+      include_enduse_subcategories: true
+      output_variables:
+        - Zone Mean Air Temperature
+    reporting_measures:
+      - measure_dir_name: ReportingMeasure1
+
+references:
+  vintage_logic: &vintage_logic
+      - or:
+        - Insulation Slab|Good Option
+        - Insulation Slab|None
+      - not: Insulation Wall|Good Option
+      - and:
+          - Vintage|1960s||Vintage|1960s
+          - Vintage|1980s
+
+upgrades:
+  - upgrade_name: cool upgrade
+    options:
+      - option: Vintage<1940
+  - upgrade_name: good upgrade
+    options:
+      - option: Vintage|<1940
+        apply_logic: **vintage_logic
+        costs:
+          - value: 0.9
+            multiplier: Fixed (1)
+      - option: Insulation Finished Basement|Good Option
+        apply_logic:
+          - Insulation Unfinished Basement|Extra Argument
+    package_apply_logic: Vintage|1960s||Vintage|1940s
+    reference_scenario: cool upgrade

--- a/buildstockbatch/test/test_inputs/enforce-validate-measures-good-2-with-anchors.yml
+++ b/buildstockbatch/test/test_inputs/enforce-validate-measures-good-2-with-anchors.yml
@@ -40,7 +40,7 @@ upgrades:
   - upgrade_name: good upgrade
     options:
       - option: Vintage|<1940
-        apply_logic: **vintage_logic
+        apply_logic: *vintage_logic
         costs:
           - value: 0.9
             multiplier: Fixed (1)

--- a/buildstockbatch/test/test_validation.py
+++ b/buildstockbatch/test/test_validation.py
@@ -157,6 +157,7 @@ def test_bad_measures(project_file):
 
 @pytest.mark.parametrize("project_file", [
     os.path.join(example_yml_dir, 'enforce-validate-measures-good-2.yml'),
+    os.path.join(example_yml_dir, 'enforce-validate-measures-good-2-with-anchors.yml')
 ])
 def test_good_measures(project_file):
     with LogCapture(level=logging.INFO) as logs:

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -40,3 +40,9 @@ Development Changelog
         :pullreq: 362
 
         Enforce Athena database name and table name to follow strict alphanumeric only naming convention.
+
+    .. change::
+        :tags: validation, feature
+        :pullreq: 366
+
+        Add a references section in the yaml schema to allow defining the anchors at a single place.

--- a/docs/project_defn.rst
+++ b/docs/project_defn.rst
@@ -49,7 +49,7 @@ To use your own custom weather files for a specific location, this can be done i
 - Rename your custom .epw weather file to match the references in your local `options_lookup.tsv <https://github.com/NREL/resstock/blob/master/resources/options_lookup.tsv>`_ in the ``resources`` folder.
 
 References
-~~~~~~~
+~~~~~~~~~~
 This is a throwaway section where you can define YAML anchors so that these can be used elsewhere in the yaml. Things defined here have no impact in the simulation and is purely used for anchor definitions.
 
 Sampler

--- a/docs/project_defn.rst
+++ b/docs/project_defn.rst
@@ -48,6 +48,10 @@ To use your own custom weather files for a specific location, this can be done i
 
 - Rename your custom .epw weather file to match the references in your local `options_lookup.tsv <https://github.com/NREL/resstock/blob/master/resources/options_lookup.tsv>`_ in the ``resources`` folder.
 
+References
+~~~~~~~
+This is a throwaway section where you can define YAML anchors so that these can be used elsewhere in the yaml. Things defined here have no impact in the simulation and is purely used for anchor definitions.
+
 Sampler
 ~~~~~~~
 

--- a/project_resstock_national.yml
+++ b/project_resstock_national.yml
@@ -5,13 +5,16 @@ output_directory: /scratch/nmerket/national_test_outputs2
 # weather_files_url: https://data.nrel.gov/system/files/156/BuildStock_TMY3_FIPS.zip
 weather_files_path: /shared-projects/buildstock/weather/BuildStock_TMY3_FIPS.zip  # Relative to this file or absolute path to zipped weather files
 
+references:
+    logic: &my_logic
+      - Geometry Building Type RECS|Single-Family Detached
+      - Vacancy Status|Occupied
+
 sampler:
   type: residential_quota_downselect
   args:
     n_datapoints: 350000
-    logic:
-      - Geometry Building Type RECS|Single-Family Detached
-      - Vacancy Status|Occupied
+    logic: *my_logic
     resample: false
 
 workflow_generator:


### PR DESCRIPTION
Add a throwaway section in the yaml schema called references where yaml anchor references can be defined to be used in other places. Without this dedicated section, there is no way to define all the references at single location and one would have to define their anchor at the first point of use. 