### PR TITLE
Exclude None from default_na_values list when reading csv files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
           wget --quiet https://data.nrel.gov/system/files/156/BuildStock_TMY3_FIPS.zip
       - name: Download and Install OpenStudio
         run: |
-          wget -q https://github.com/NREL/OpenStudio/releases/download/v3.5.1/OpenStudio-3.5.1+22e1db7be5-Ubuntu-20.04.deb
-          sudo apt install -y ./OpenStudio-3.5.1+22e1db7be5-Ubuntu-20.04.deb
+          wget -q https://github.com/NREL/OpenStudio/releases/download/v3.6.1/OpenStudio-3.6.1+bb9481519e-Ubuntu-20.04-x86_64.deb
+          sudo apt install -y ./OpenStudio-3.6.1+bb9481519e-Ubuntu-20.04-x86_64.deb
           openstudio openstudio_version
           which openstudio
       - name: Install buildstockbatch

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage/
 .coverage
 build/
 .env
+.history

--- a/buildstockbatch/aws/aws.py
+++ b/buildstockbatch/aws/aws.py
@@ -1858,6 +1858,7 @@ class AwsBatch(DockerBatchBase):
 
             # Collect simulations to queue
             df = read_csv(buildstock_csv_filename, index_col=0)
+            self.validate_buildstock_csv(self.project_filename, df)
             building_ids = df.index.tolist()
             n_datapoints = len(building_ids)
             n_sims = n_datapoints * (len(self.cfg.get('upgrades', [])) + 1)

--- a/buildstockbatch/aws/aws.py
+++ b/buildstockbatch/aws/aws.py
@@ -1857,7 +1857,7 @@ class AwsBatch(DockerBatchBase):
                 json.dump(self.cfg, f)
 
             # Collect simulations to queue
-            df = read_csv(buildstock_csv_filename, index_col=0)
+            df = read_csv(buildstock_csv_filename, index_col=0, dtype=str)
             self.validate_buildstock_csv(self.project_filename, df)
             building_ids = df.index.tolist()
             n_datapoints = len(building_ids)

--- a/buildstockbatch/aws/aws.py
+++ b/buildstockbatch/aws/aws.py
@@ -26,7 +26,6 @@ import json
 import logging
 import math
 import os
-import pandas as pd
 import pathlib
 import random
 from s3fs import S3FileSystem
@@ -42,7 +41,7 @@ import zipfile
 from buildstockbatch.base import ValidationError, BuildStockBatchBase
 from buildstockbatch.aws.awsbase import AwsJobBase
 from buildstockbatch import postprocessing
-from buildstockbatch.utils import ContainerRuntime, log_error_details, get_project_configuration
+from buildstockbatch.utils import ContainerRuntime, log_error_details, get_project_configuration, read_csv
 
 logger = logging.getLogger(__name__)
 
@@ -1858,7 +1857,7 @@ class AwsBatch(DockerBatchBase):
                 json.dump(self.cfg, f)
 
             # Collect simulations to queue
-            df = pd.read_csv(buildstock_csv_filename, index_col=0)
+            df = read_csv(buildstock_csv_filename, index_col=0)
             building_ids = df.index.tolist()
             n_datapoints = len(building_ids)
             n_sims = n_datapoints * (len(self.cfg.get('upgrades', [])) + 1)

--- a/buildstockbatch/base.py
+++ b/buildstockbatch/base.py
@@ -321,7 +321,7 @@ class BuildStockBatchBase(object):
                 sample_file = os.path.join(os.path.dirname(project_file), sample_file)
             else:
                 sample_file = os.path.abspath(sample_file)
-            buildstock_df = read_csv(sample_file)
+            buildstock_df = read_csv(sample_file, dtype=str)
             BuildStockBatchBase.validate_buildstock_csv(project_file, buildstock_df)
         return True
 

--- a/buildstockbatch/eagle.py
+++ b/buildstockbatch/eagle.py
@@ -198,7 +198,7 @@ class EagleBatch(BuildStockBatchBase):
             return
 
         # Determine the number of simulations expected to be executed
-        df = read_csv(buildstock_csv_filename, index_col=0)
+        df = read_csv(buildstock_csv_filename, index_col=0, dtype=str)
         self.validate_buildstock_csv(self.project_filename, df)
 
         # find out how many buildings there are to simulate

--- a/buildstockbatch/eagle.py
+++ b/buildstockbatch/eagle.py
@@ -41,7 +41,8 @@ from buildstockbatch.utils import (
     get_error_details,
     ContainerRuntime,
     path_rel_to_file,
-    get_project_configuration
+    get_project_configuration,
+    read_csv
 )
 from buildstockbatch import postprocessing
 from buildstockbatch.__version__ import __version__ as bsb_version
@@ -91,7 +92,8 @@ class EagleBatch(BuildStockBatchBase):
         cfg = get_project_configuration(project_file)
         output_dir = path_rel_to_file(project_file, cfg['output_directory'])
         if not (output_dir.startswith('/scratch') or output_dir.startswith('/projects')):
-            raise ValidationError(f"`output_directory` must be in /scratch or /projects, `output_directory` = {output_dir}")
+            raise ValidationError(f"`output_directory` must be in /scratch or /projects,"
+                                  f" `output_directory` = {output_dir}")
 
     @property
     def output_dir(self):
@@ -196,7 +198,7 @@ class EagleBatch(BuildStockBatchBase):
             return
 
         # Determine the number of simulations expected to be executed
-        df = pd.read_csv(buildstock_csv_filename, index_col=0)
+        df = read_csv(buildstock_csv_filename, index_col=0)
 
         # find out how many buildings there are to simulate
         building_ids = df.index.tolist()

--- a/buildstockbatch/eagle.py
+++ b/buildstockbatch/eagle.py
@@ -199,6 +199,7 @@ class EagleBatch(BuildStockBatchBase):
 
         # Determine the number of simulations expected to be executed
         df = read_csv(buildstock_csv_filename, index_col=0)
+        self.validate_buildstock_csv(self.project_filename, df)
 
         # find out how many buildings there are to simulate
         building_ids = df.index.tolist()

--- a/buildstockbatch/local.py
+++ b/buildstockbatch/local.py
@@ -21,7 +21,6 @@ from joblib import Parallel, delayed
 import json
 import logging
 import os
-import pandas as pd
 import pathlib
 import re
 import shutil
@@ -30,7 +29,7 @@ import tarfile
 
 from buildstockbatch.base import BuildStockBatchBase, SimulationExists
 from buildstockbatch import postprocessing
-from buildstockbatch.utils import log_error_details, ContainerRuntime
+from buildstockbatch.utils import log_error_details, ContainerRuntime, read_csv
 from buildstockbatch.__version__ import __version__ as bsb_version
 
 logger = logging.getLogger(__name__)
@@ -232,7 +231,7 @@ class LocalBatch(BuildStockBatchBase):
         shutil.copytree(buildstock_path / "resources", lib_path / "resources")
         shutil.copytree(project_path / "housing_characteristics", lib_path / "housing_characteristics")
 
-        df = pd.read_csv(buildstock_csv_filename, index_col=0)
+        df = read_csv(buildstock_csv_filename, index_col=0)
         building_ids = df.index.tolist()
         n_datapoints = len(building_ids)
         run_building_d = functools.partial(

--- a/buildstockbatch/local.py
+++ b/buildstockbatch/local.py
@@ -231,7 +231,7 @@ class LocalBatch(BuildStockBatchBase):
         shutil.copytree(buildstock_path / "resources", lib_path / "resources")
         shutil.copytree(project_path / "housing_characteristics", lib_path / "housing_characteristics")
 
-        df = read_csv(buildstock_csv_filename, index_col=0)
+        df = read_csv(buildstock_csv_filename, index_col=0, dtype=str)
         self.validate_buildstock_csv(self.project_filename, df)
 
         building_ids = df.index.tolist()

--- a/buildstockbatch/local.py
+++ b/buildstockbatch/local.py
@@ -232,6 +232,8 @@ class LocalBatch(BuildStockBatchBase):
         shutil.copytree(project_path / "housing_characteristics", lib_path / "housing_characteristics")
 
         df = read_csv(buildstock_csv_filename, index_col=0)
+        self.validate_buildstock_csv(self.project_filename, df)
+
         building_ids = df.index.tolist()
         n_datapoints = len(building_ids)
         run_building_d = functools.partial(

--- a/buildstockbatch/sampler/commercial_sobol.py
+++ b/buildstockbatch/sampler/commercial_sobol.py
@@ -21,7 +21,7 @@ from warnings import warn
 
 from .sobol_lib import i4_sobol_generate
 from .base import BuildStockSampler
-from buildstockbatch.utils import ContainerRuntime
+from buildstockbatch.utils import ContainerRuntime, read_csv
 from buildstockbatch.exc import ValidationError
 
 logger = logging.getLogger(__name__)
@@ -81,7 +81,7 @@ class CommercialSobolSampler(BuildStockSampler):
         tsv_hash = {}
         for tsv_file in os.listdir(self.buildstock_dir):
             if '.tsv' in tsv_file:
-                tsv_df = pd.read_csv(os.path.join(self.buildstock_dir, tsv_file), sep='\t')
+                tsv_df = read_csv(os.path.join(self.buildstock_dir, tsv_file), sep='\t')
                 dependency_columns = [item for item in list(tsv_df) if 'Dependency=' in item]
                 tsv_df[dependency_columns] = tsv_df[dependency_columns].astype('str')
                 tsv_hash[tsv_file.replace('.tsv', '')] = tsv_df

--- a/buildstockbatch/sampler/downselect.py
+++ b/buildstockbatch/sampler/downselect.py
@@ -12,11 +12,11 @@ import logging
 import math
 import numpy as np
 import os
-import pandas as pd
 import shutil
 
 from .base import BuildStockSampler
 from buildstockbatch.exc import ValidationError
+from buildstockbatch.utils import read_csv
 
 logger = logging.getLogger(__name__)
 
@@ -107,7 +107,7 @@ class DownselectSamplerBase(BuildStockSampler):
             n_samples_init = 350000
             init_sampler = self.SUB_SAMPLER_CLASS(self.parent(), n_datapoints=n_samples_init, **self.sub_kw)
             buildstock_csv_filename = init_sampler.run_sampling()
-            df = pd.read_csv(buildstock_csv_filename, index_col=0)
+            df = read_csv(buildstock_csv_filename, index_col=0)
             df_new = df[self.downselect_logic(df, self.logic)]
             downselected_n_samples_init = df_new.shape[0]
             n_samples = math.ceil(self.n_datapoints * n_samples_init / downselected_n_samples_init)
@@ -120,7 +120,7 @@ class DownselectSamplerBase(BuildStockSampler):
         with gzip.open(os.path.splitext(buildstock_csv_filename)[0] + '_orig.csv.gz', 'wb') as f_out:
             with open(buildstock_csv_filename, 'rb') as f_in:
                 shutil.copyfileobj(f_in, f_out)
-        df = pd.read_csv(buildstock_csv_filename, index_col=0, dtype='str')
+        df = read_csv(buildstock_csv_filename, index_col=0, dtype='str')
         df_new = df[self.downselect_logic(df, self.logic)]
         if len(df_new.index) == 0:
             raise RuntimeError('There are no buildings left after the down select!')

--- a/buildstockbatch/sampler/downselect.py
+++ b/buildstockbatch/sampler/downselect.py
@@ -107,7 +107,7 @@ class DownselectSamplerBase(BuildStockSampler):
             n_samples_init = 350000
             init_sampler = self.SUB_SAMPLER_CLASS(self.parent(), n_datapoints=n_samples_init, **self.sub_kw)
             buildstock_csv_filename = init_sampler.run_sampling()
-            df = read_csv(buildstock_csv_filename, index_col=0)
+            df = read_csv(buildstock_csv_filename, index_col=0, dtype=str)
             df_new = df[self.downselect_logic(df, self.logic)]
             downselected_n_samples_init = df_new.shape[0]
             n_samples = math.ceil(self.n_datapoints * n_samples_init / downselected_n_samples_init)

--- a/buildstockbatch/test/test_base.py
+++ b/buildstockbatch/test/test_base.py
@@ -399,7 +399,7 @@ def test_skipping_baseline(basic_residential_project_file):
 
 def test_provide_buildstock_csv(basic_residential_project_file, mocker):
     buildstock_csv = os.path.join(here, 'buildstock.csv')
-    df = read_csv(buildstock_csv)
+    df = read_csv(buildstock_csv, dtype=str)
     project_filename, results_dir = basic_residential_project_file({
         'sampler': {
             'type': 'precomputed',
@@ -413,7 +413,7 @@ def test_provide_buildstock_csv(basic_residential_project_file, mocker):
 
     bsb = LocalBatch(project_filename)
     sampling_output_csv = bsb.sampler.run_sampling()
-    df2 = read_csv(sampling_output_csv)
+    df2 = read_csv(sampling_output_csv, dtype=str)
     pd.testing.assert_frame_equal(df, df2)
     assert (df['Geometry Shared Walls'] == "None").all()  # Verify None is being read properly
     # Test file missing

--- a/buildstockbatch/test/test_eagle.py
+++ b/buildstockbatch/test/test_eagle.py
@@ -282,7 +282,7 @@ def test_run_building_process(mocker,  basic_residential_project_file):
 
     # Check that buildstock.csv was trimmed properly
     local_buildstock_df = read_csv(results_dir / 'local_housing_characteristics_dir' / 'buildstock.csv', dtype=str)
-    unique_buildings = {x[0] for x in job_json['batch']}
+    unique_buildings = {str(x[0]) for x in job_json['batch']}
     assert len(unique_buildings) == len(local_buildstock_df)
     assert unique_buildings == set(local_buildstock_df['Building'])
 

--- a/buildstockbatch/test/test_eagle.py
+++ b/buildstockbatch/test/test_eagle.py
@@ -11,7 +11,7 @@ import gzip
 
 from buildstockbatch.eagle import user_cli, EagleBatch
 from buildstockbatch.base import BuildStockBatchBase
-from buildstockbatch.utils import get_project_configuration
+from buildstockbatch.utils import get_project_configuration, read_csv
 
 here = os.path.dirname(os.path.abspath(__file__))
 
@@ -281,7 +281,7 @@ def test_run_building_process(mocker,  basic_residential_project_file):
         compare_ts_parquets(file, results_file)
 
     # Check that buildstock.csv was trimmed properly
-    local_buildstock_df = pd.read_csv(results_dir / 'local_housing_characteristics_dir' / 'buildstock.csv')
+    local_buildstock_df = read_csv(results_dir / 'local_housing_characteristics_dir' / 'buildstock.csv')
     unique_buildings = {x[0] for x in job_json['batch']}
     assert len(unique_buildings) == len(local_buildstock_df)
     assert unique_buildings == set(local_buildstock_df['Building'])

--- a/buildstockbatch/test/test_eagle.py
+++ b/buildstockbatch/test/test_eagle.py
@@ -281,7 +281,7 @@ def test_run_building_process(mocker,  basic_residential_project_file):
         compare_ts_parquets(file, results_file)
 
     # Check that buildstock.csv was trimmed properly
-    local_buildstock_df = read_csv(results_dir / 'local_housing_characteristics_dir' / 'buildstock.csv')
+    local_buildstock_df = read_csv(results_dir / 'local_housing_characteristics_dir' / 'buildstock.csv', dtype=str)
     unique_buildings = {x[0] for x in job_json['batch']}
     assert len(unique_buildings) == len(local_buildstock_df)
     assert unique_buildings == set(local_buildstock_df['Building'])

--- a/buildstockbatch/test/test_inputs/test_openstudio_buildstock/resources/buildstock_bad.csv
+++ b/buildstockbatch/test/test_inputs/test_openstudio_buildstock/resources/buildstock_bad.csv
@@ -1,6 +1,6 @@
-Building,Location,Vintage,State,Insulation Wall,Insulation
-1,AL_Mobile-Rgnl.AP.722230,1940-1950,CO,Good Option,None
-2,AL_Mobile-Rgnl.AP.722230,1940s,CO,Good Option,None
-3,AL_Mobile-Rgnl.AP.722230,2010s,VA,Good Option,None
-4,AL_Mobile-Rgnl.AP.722230,2000s,TX,,None
-5,AL_Mobile-Rgnl.AP.722230,1970s,VA,,None
+Building,Bedroom,Location,Vintage,State,Insulation Wall,Insulation
+1,1,AL_Mobile-Rgnl.AP.722230,1940-1950,CO,Good Option,None
+2,2,AL_Mobile-Rgnl.AP.722230,1940s,CO,Good Option,None
+3,2,AL_Mobile-Rgnl.AP.722230,2010s,VA,Good Option,None
+4,2,AL_Mobile-Rgnl.AP.722230,2000s,TX,,None
+5,3,AL_Mobile-Rgnl.AP.722230,1970s,VA,,None

--- a/buildstockbatch/test/test_inputs/test_openstudio_buildstock/resources/buildstock_bad.csv
+++ b/buildstockbatch/test/test_inputs/test_openstudio_buildstock/resources/buildstock_bad.csv
@@ -1,0 +1,6 @@
+Building,Location,Vintage,State,Insulation Wall,Insulation
+1,AL_Mobile-Rgnl.AP.722230,1940-1950,CO,Good Option,None
+2,AL_Mobile-Rgnl.AP.722230,1940s,CO,Good Option,None
+3,AL_Mobile-Rgnl.AP.722230,2010s,VA,Good Option,None
+4,AL_Mobile-Rgnl.AP.722230,2000s,TX,,None
+5,AL_Mobile-Rgnl.AP.722230,1970s,VA,,None

--- a/buildstockbatch/test/test_inputs/test_openstudio_buildstock/resources/buildstock_good.csv
+++ b/buildstockbatch/test/test_inputs/test_openstudio_buildstock/resources/buildstock_good.csv
@@ -1,0 +1,6 @@
+Building,Location,Vintage,State,Insulation Wall,Insulation Slab
+1,AL_Mobile-Rgnl.AP.722230,<1950,CO,Good Option,None
+2,AL_Mobile-Rgnl.AP.722230,1940s,CO,Good Option,None
+3,AL_Mobile-Rgnl.AP.722230,2010s,VA,Good Option,None
+4,AL_Mobile-Rgnl.AP.722230,2000s,VA,Good Option,None
+5,AL_Mobile-Rgnl.AP.722230,1970s,VA,Good Option,None

--- a/buildstockbatch/test/test_inputs/test_openstudio_buildstock/resources/buildstock_good.csv
+++ b/buildstockbatch/test/test_inputs/test_openstudio_buildstock/resources/buildstock_good.csv
@@ -1,6 +1,6 @@
-Building,Location,Vintage,State,Insulation Wall,Insulation Slab
-1,AL_Mobile-Rgnl.AP.722230,<1950,CO,Good Option,None
-2,AL_Mobile-Rgnl.AP.722230,1940s,CO,Good Option,None
-3,AL_Mobile-Rgnl.AP.722230,2010s,VA,Good Option,None
-4,AL_Mobile-Rgnl.AP.722230,2000s,VA,Good Option,None
-5,AL_Mobile-Rgnl.AP.722230,1970s,VA,Good Option,None
+Building,Bedroom,Location,Vintage,State,Insulation Wall,Insulation Slab
+1,1,AL_Mobile-Rgnl.AP.722230,<1950,CO,Good Option,None
+2,3,AL_Mobile-Rgnl.AP.722230,1940s,CO,Good Option,None
+3,2,AL_Mobile-Rgnl.AP.722230,2010s,VA,Good Option,None
+4,1,AL_Mobile-Rgnl.AP.722230,2000s,VA,Good Option,None
+5,2,AL_Mobile-Rgnl.AP.722230,1970s,VA,Good Option,None

--- a/buildstockbatch/test/test_inputs/test_openstudio_buildstock/resources/options_lookup.tsv
+++ b/buildstockbatch/test/test_inputs/test_openstudio_buildstock/resources/options_lookup.tsv
@@ -16,6 +16,9 @@ State	VA
 State	CO															
 County	County1															
 County	County2															
+Bedroom	1															
+Bedroom	2															
+Bedroom	3															
 Insulation Slab	None															
 Insulation Slab	Good Option	ResidentialConstructionsSlab	perimeter_r=0	perimeter_width=0	whole_r=0	gap_r=0	exterior_r=0	exterior_depth=0								
 Insulation Slab	Missing Argument	ResidentialConstructionsSlab	perimeter_r=0	perimeter_width=0	whole_r=10	gap_r=5	exterior_r=0									

--- a/buildstockbatch/test/test_postprocessing.py
+++ b/buildstockbatch/test/test_postprocessing.py
@@ -3,7 +3,6 @@ import gzip
 import json
 import logging
 import os
-import pandas as pd
 import pathlib
 import re
 import tarfile
@@ -13,7 +12,7 @@ from unittest.mock import patch, MagicMock
 
 from buildstockbatch import postprocessing
 from buildstockbatch.base import BuildStockBatchBase
-from buildstockbatch.utils import get_project_configuration
+from buildstockbatch.utils import get_project_configuration, read_csv
 
 postprocessing.performance_report = MagicMock()
 
@@ -58,7 +57,7 @@ def test_report_additional_results_csv_columns(basic_residential_project_file):
     postprocessing.combine_results(fs, results_dir, cfg, do_timeseries=False)
 
     for upgrade_id in (0, 1):
-        df = pd.read_csv(str(results_dir / 'results_csvs' / f'results_up{upgrade_id:02d}.csv.gz'))
+        df = read_csv(str(results_dir / 'results_csvs' / f'results_up{upgrade_id:02d}.csv.gz'))
         assert (df['reporting_measure1.column_1'] == 1).all()
         assert (df['reporting_measure1.column_2'] == 2).all()
         assert (df['reporting_measure2.column_3'] == 3).all()

--- a/buildstockbatch/test/test_validation.py
+++ b/buildstockbatch/test/test_validation.py
@@ -20,7 +20,6 @@ import pathlib
 from buildstockbatch.eagle import EagleBatch
 from buildstockbatch.local import LocalBatch
 from buildstockbatch.base import BuildStockBatchBase, ValidationError
-from buildstockbatch.eagle import EagleBatch
 from buildstockbatch.test.shared_testing_stuff import resstock_directory, resstock_required
 from buildstockbatch.utils import get_project_configuration
 from unittest.mock import patch
@@ -139,7 +138,7 @@ def test_good_reference_scenario(project_file):
 ])
 def test_bad_measures(project_file):
 
-    with LogCapture(level=logging.INFO) as logs:
+    with LogCapture(level=logging.INFO) as _:
         try:
             BuildStockBatchBase.validate_workflow_generator(project_file)
         except (ValidationError, YamaleError) as er:

--- a/buildstockbatch/test/test_validation.py
+++ b/buildstockbatch/test/test_validation.py
@@ -20,8 +20,9 @@ import pathlib
 from buildstockbatch.eagle import EagleBatch
 from buildstockbatch.local import LocalBatch
 from buildstockbatch.base import BuildStockBatchBase, ValidationError
+import pandas as pd
 from buildstockbatch.test.shared_testing_stuff import resstock_directory, resstock_required
-from buildstockbatch.utils import get_project_configuration
+from buildstockbatch.utils import get_project_configuration, read_csv
 from unittest.mock import patch
 from testfixtures import LogCapture
 from yamale.yamale_error import YamaleError
@@ -30,7 +31,7 @@ import yaml
 
 here = os.path.dirname(os.path.abspath(__file__))
 example_yml_dir = os.path.join(here, 'test_inputs')
-
+resources_dir = os.path.join(here, 'test_inputs', 'test_openstudio_buildstock', 'resources')
 
 def filter_logs(logs, level):
     filtered_logs = ''
@@ -303,3 +304,35 @@ def test_validate_eagle_output_directory():
             with open(temp_yml, 'w') as f:
                 yaml.dump(cfg, f, Dumper=yaml.SafeDumper)
             EagleBatch.validate_output_directory_eagle(str(temp_yml))
+
+
+def test_validate_sampler_good_buildstock(basic_residential_project_file):
+    project_filename, _ = basic_residential_project_file({
+        'sampler': {
+            'type': 'precomputed',
+            'args': {
+                'sample_file': str(os.path.join(resources_dir, 'buildstock_good.csv'))
+            }
+        }
+    })
+    assert BuildStockBatchBase.validate_sampler(project_filename)
+
+def test_validate_sampler_bad_buildstock(basic_residential_project_file):
+    project_filename, _ = basic_residential_project_file({
+        'sampler': {
+            'type': 'precomputed',
+            'args': {
+                'sample_file': str(os.path.join(resources_dir, 'buildstock_bad.csv'))
+            }
+        }
+    })
+    try:
+        BuildStockBatchBase.validate_sampler(project_filename)
+    except ValidationError as er:
+        er = str(er)
+        assert 'Option 1940-1950 in column Vintage of buildstock_csv is not available in options_lookup.tsv' in er
+        assert 'Option TX in column State of buildstock_csv is not available in options_lookup.tsv' in er
+        assert 'Option nan in column Insulation Wall of buildstock_csv is not available in options_lookup.tsv' in er
+        assert 'Column Insulation in buildstock_csv is not available in options_lookup.tsv' in er
+    else:
+        raise Exception("validate_options was supposed to raise ValidationError for enforce-validate-options-good.yml")

--- a/buildstockbatch/utils.py
+++ b/buildstockbatch/utils.py
@@ -4,6 +4,8 @@ import os
 import logging
 import traceback
 import yaml
+import pandas as pd
+
 
 logger = logging.getLogger(__name__)
 
@@ -12,6 +14,12 @@ class ContainerRuntime(enum.Enum):
     DOCKER = 1
     SINGULARITY = 2
     LOCAL_OPENSTUDIO = 3
+
+
+def read_csv(csv_file_path, **kwargs) -> pd.DataFrame:
+    default_na_values = pd._libs.parsers.STR_NA_VALUES
+    df = pd.read_csv(csv_file_path, na_values=list(default_na_values - {"None"}), keep_default_na=False, **kwargs)
+    return df
 
 
 def path_rel_to_file(startfile, x):

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -14,3 +14,11 @@ Development Changelog
         This is an example change. Please copy and paste it - for valid tags please refer to ``conf.py`` in the docs
         directory. ``pullreq`` should be set to the appropriate pull request number and ``tickets`` to any related
         github issues. These will be automatically linked in the documentation.
+
+    .. change::
+        :tags: bugfix, feature
+        :pullreq: 374
+        :tickets: 373
+
+        Add read_csv function to utils to handle parsing "None" correctly with pandas > 2.0+. Also add a validator for
+        buildstock_csv that checks if all the entries are available in the options_lookup.tsv.

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
         'pyyaml',
         'requests',
         'numpy',
-        'pandas',
+        'pandas>2.0',
         'joblib',
         'pyarrow',
         'dask[complete]>=2022.10.0',

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
         'pyyaml',
         'requests',
         'numpy',
-        'pandas>2.0',
+        'pandas>=2',
         'joblib',
         'pyarrow',
         'dask[complete]>=2022.10.0',


### PR DESCRIPTION
[Pandas 2.0 added "None" to default na_values in read_csv()](https://pandas.pydata.org/docs/dev/whatsnew/v2.0.0.html#other-api-changes).

This causes breaking change from previous version when reading buildstock.csv or other files that has the string "None". This PR adds a custom read_csv function that restores previous behavior. It should also fix #373. 