### PR TITLE
ResStock-HPXML: resilience and bill arguments

### DIFF
--- a/buildstockbatch/workflow_generator/residential_hpxml.py
+++ b/buildstockbatch/workflow_generator/residential_hpxml.py
@@ -388,6 +388,9 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
         if 'include_annual_hvac_summary' in sim_out_rep_args_avail:
             sim_out_rep_args['include_annual_hvac_summary'] = True
 
+        if 'include_annual_resilience' in sim_out_rep_args_avail:
+            sim_out_rep_args['include_annual_resilience'] = True
+
         if 'include_timeseries_system_use_consumptions' in sim_out_rep_args_avail:
             sim_out_rep_args['include_timeseries_system_use_consumptions'] = False
 

--- a/buildstockbatch/workflow_generator/residential_hpxml.py
+++ b/buildstockbatch/workflow_generator/residential_hpxml.py
@@ -110,6 +110,7 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
             include_timeseries_zone_temperatures: bool(required=False)
             include_timeseries_airflows: bool(required=False)
             include_timeseries_weather: bool(required=False)
+            include_timeseries_resilience: bool(required=False)
             timeseries_timestamp_convention: enum('start', 'end', required=False)
             timeseries_num_decimal_places: int(required=False)
             add_timeseries_dst_column: bool(required=False)
@@ -393,6 +394,9 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
         if 'include_timeseries_unmet_hours' in sim_out_rep_args_avail:
             sim_out_rep_args['include_timeseries_unmet_hours'] = False
 
+        if 'include_timeseries_resilience' in sim_out_rep_args_avail:
+            sim_out_rep_args['include_timeseries_resilience'] = False
+
         if 'timeseries_num_decimal_places' in sim_out_rep_args_avail:
             sim_out_rep_args['timeseries_num_decimal_places'] = 3
 
@@ -402,6 +406,18 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
             output_variables = sim_out_rep_args['output_variables']
             sim_out_rep_args['user_output_variables'] = ','.join([str(s.get('name')) for s in output_variables])
             sim_out_rep_args.pop('output_variables')
+
+        util_bills_rep_args = {}
+
+        measures_dir = os.path.join(buildstock_dir, 'resources/hpxml-measures')
+        measure_path = os.path.join(measures_dir, 'ReportUtilityBills')
+        util_bills_rep_args_avail = get_measure_arguments(os.path.join(measure_path, 'measure.xml'))
+
+        if 'include_annual_bills' in util_bills_rep_args_avail:
+            util_bills_rep_args['include_annual_bills'] = True
+
+        if 'include_monthly_bills' in util_bills_rep_args_avail:
+            util_bills_rep_args['include_monthly_bills'] = False
 
         osw = {
             'id': sim_id,
@@ -474,7 +490,7 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
             },
             {
                 'measure_dir_name': 'ReportUtilityBills',
-                'arguments': {}
+                'arguments': util_bills_rep_args
             },
             {
                 'measure_dir_name': 'UpgradeCosts',

--- a/buildstockbatch/workflow_generator/test_workflow_generator.py
+++ b/buildstockbatch/workflow_generator/test_workflow_generator.py
@@ -114,6 +114,7 @@ def test_residential_hpxml(mocker):
     assert simulation_output_step['arguments']['include_annual_component_loads'] is True
     assert simulation_output_step['arguments']['include_annual_hot_water_uses'] is True
     assert simulation_output_step['arguments']['include_annual_hvac_summary'] is True
+    assert simulation_output_step['arguments']['include_annual_resilience'] is True
     assert simulation_output_step['arguments']['include_timeseries_total_consumptions'] is True
     assert simulation_output_step['arguments']['include_timeseries_fuel_consumptions'] is False
     assert simulation_output_step['arguments']['include_timeseries_end_use_consumptions'] is True

--- a/buildstockbatch/workflow_generator/test_workflow_generator.py
+++ b/buildstockbatch/workflow_generator/test_workflow_generator.py
@@ -128,6 +128,7 @@ def test_residential_hpxml(mocker):
     assert simulation_output_step['arguments']['include_timeseries_zone_temperatures'] is False
     assert simulation_output_step['arguments']['include_timeseries_airflows'] is False
     assert simulation_output_step['arguments']['include_timeseries_weather'] is False
+    assert simulation_output_step['arguments']['include_timeseries_resilience'] is False
     assert simulation_output_step['arguments']['timeseries_timestamp_convention'] == 'end'
     assert simulation_output_step['arguments']['timeseries_num_decimal_places'] == 3
     assert simulation_output_step['arguments']['add_timeseries_dst_column'] is True
@@ -136,8 +137,10 @@ def test_residential_hpxml(mocker):
     hpxml_output_step = steps[4]
     assert hpxml_output_step['measure_dir_name'] == 'ReportHPXMLOutput'
 
-    hpxml_output_step = steps[5]
-    assert hpxml_output_step['measure_dir_name'] == 'ReportUtilityBills'
+    utility_bills_step = steps[5]
+    assert utility_bills_step['measure_dir_name'] == 'ReportUtilityBills'
+    assert utility_bills_step['arguments']['include_annual_bills'] is True
+    assert utility_bills_step['arguments']['include_monthly_bills'] is False
 
     upgrade_costs_step = steps[6]
     assert upgrade_costs_step['measure_dir_name'] == 'UpgradeCosts'

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -29,3 +29,11 @@ Development Changelog
 
         No longer automatically downloads the appropriate singularity image from
         S3. Also added validation to ensure the image is in the correct location.
+
+    .. change::
+        :tags: general, feature
+        :pullreq: 383
+
+        For the Residential HPXML Workflow Generator, fixes new ``include_annual_resilience`` argument to true and
+        adds a new optional ``include_timeseries_resilience`` argument that defaults to false. Also fixes new
+        ``include_annual_bills`` argument to true and ``include_monthly_bills`` argument to false.

--- a/docs/workflow_generators/residential_hpxml.rst
+++ b/docs/workflow_generators/residential_hpxml.rst
@@ -108,6 +108,7 @@ Arguments
   - ``include_timeseries_zone_temperatures``: Generates timeseries average temperatures (in deg-F) for each space modeled (e.g., living space, attic, garage, basement, crawlspace, etc.). 
   - ``include_timeseries_airflows``: Generates timeseries airflow rates (in cfm) for infiltration, mechanical ventilation (including clothes dryer exhaust), natural ventilation, whole house fans.
   - ``include_timeseries_weather``: Generates timeseries weather file data including outdoor temperatures, relative humidity, wind speed, and solar.
+  - ``include_timeseries_resilience``: Generates timeseries resilience outputs.
   - ``timeseries_timestamp_convention``: Determines whether timeseries timestamps use the start-of-timestep or end-of-timestep convention. Valid choices are 'start' and 'end'.
   - ``timeseries_num_decimal_places``: Allows overriding the default number of decimal places for timeseries output.
   - ``add_timeseries_dst_column``: Optionally add, in addition to the default local standard Time column, a local clock TimeDST column. Requires that daylight saving time is enabled.


### PR DESCRIPTION
Closes #381.

Support the following ReportSimulationOutput changes:
* Arguments `include_annual_resilience` and `include_timeseries_resilience` are now available. We will fix (i.e., user has no option to override) requesting annual resilience outputs. Requesting timeseries resilience outputs is optional.

Support the following ReportUtilityBills changes:
* Arguments `include_annual_bills`, `include_monthly_bills`, and `monthly_timestamp_convention` are now available. We will fix (i.e., user has no option to override) requesting annual utility bill outputs and _not_ requesting monthly utility bill outputs.

## Checklist

- [x] Code changes (must work)
- [x] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [x] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/ci.yml` as necessary.
- [x] All other unit and integration tests passing
- [x] Update validation for project config yaml file changes
- [x] Update existing documentation
- [x] ~~Run a small batch run on Eagle to make sure it all works if you made changes that will affect Eagle~~
- [x] Add to the changelog_dev.rst file and propose migration text in the pull request

