### PR TITLE
No longer downloading singularity image automatically

### DIFF
--- a/buildstockbatch/eagle.py
+++ b/buildstockbatch/eagle.py
@@ -58,8 +58,7 @@ def get_bool_env_var(varname):
 class EagleBatch(BuildStockBatchBase):
 
     CONTAINER_RUNTIME = ContainerRuntime.SINGULARITY
-
-    sys_image_dir = '/shared-projects/buildstock/singularity_images'
+    DEFAULT_SYS_IMAGE_DIR = '/shared-projects/buildstock/singularity_images'
     hpc_name = 'eagle'
     min_sims_per_job = 36 * 2
 
@@ -79,11 +78,15 @@ class EagleBatch(BuildStockBatchBase):
         logger.debug('Output directory = {}'.format(output_dir))
         weather_dir = self.weather_dir  # noqa E841
 
+        self.singularity_image = self.get_singularity_image(self.cfg, self.os_version, self.os_sha)
+
+
     @classmethod
     def validate_project(cls, project_file):
         super(cls, cls).validate_project(project_file)
         # Eagle specific validation goes here
         cls.validate_output_directory_eagle(project_file)
+        cls.validate_singularity_image_eagle(project_file)
         logger.info("Eagle Validation Successful")
         return True
 
@@ -94,6 +97,19 @@ class EagleBatch(BuildStockBatchBase):
         if not (output_dir.startswith('/scratch') or output_dir.startswith('/projects')):
             raise ValidationError(f"`output_directory` must be in /scratch or /projects,"
                                   f" `output_directory` = {output_dir}")
+
+    @classmethod
+    def validate_singularity_image_eagle(cls, project_file):
+        cfg = get_project_configuration(project_file)
+        singularity_image = cls.get_singularity_image(
+            cfg, 
+            cfg.get('os_version', cls.DEFAULT_OS_VERSION),
+            cfg.get('os_sha', cls.DEFAULT_OS_SHA)
+        )
+        if not os.path.exists(singularity_image):
+            raise ValidationError(
+                f"The singularity image does not exist: {singularity_image}"
+            )
 
     @property
     def output_dir(self):
@@ -112,53 +128,15 @@ class EagleBatch(BuildStockBatchBase):
             shutil.rmtree(dst, ignore_errors=True)
         shutil.copytree(src, dst)
 
-    @property
-    def singularity_image_url(self):
-        if '-' in self.os_version:
-            prefix_ver = self.os_version.split('-')[0]
-        else:
-            prefix_ver = self.os_version
-        return 'https://s3.amazonaws.com/openstudio-builds/{prefix_ver}/OpenStudio-{ver}.{sha}-Singularity.simg'.format(
-                    prefix_ver=prefix_ver,
-                    ver=self.os_version,
-                    sha=self.os_sha
-                )
-
-    @property
-    def singularity_image(self):
-        # Check the project yaml specification - if the file does not exist do not silently allow for non-specified simg
-        if 'sys_image_dir' in self.cfg.keys():
-            sys_image_dir = self.cfg['sys_image_dir']
-            sys_image = os.path.join(sys_image_dir, 'OpenStudio-{ver}.{sha}-Singularity.simg'.format(
-                ver=self.os_version,
-                sha=self.os_sha
-            ))
-            if os.path.isfile(sys_image):
-                return sys_image
-            else:
-                raise RuntimeError('Unable to find singularity image specified in project file: `{}`'.format(sys_image))
-        # Use the expected HPC environment default if not explicitly defined in the YAML
-        sys_image = os.path.join(self.sys_image_dir, 'OpenStudio-{ver}.{sha}-Singularity.simg'.format(
-            ver=self.os_version,
-            sha=self.os_sha
-        ))
-        if os.path.isfile(sys_image):
-            return sys_image
-        # Otherwise attempt retrieval from AWS for the appropriate os_version and os_sha
-        else:
-            singularity_image_path = os.path.join(self.output_dir, 'openstudio.simg')
-            if not os.path.isfile(singularity_image_path):
-                logger.debug(f'Downloading singularity image: {self.singularity_image_url}')
-                r = requests.get(self.singularity_image_url, stream=True)
-                if r.status_code != requests.codes.ok:
-                    logger.error('Unable to download simg file from OpenStudio releases S3 bucket.')
-                    r.raise_for_status()
-                with open(singularity_image_path, 'wb') as f:
-                    for chunk in r.iter_content(chunk_size=1024):
-                        if chunk:
-                            f.write(chunk)
-                logger.debug('Downloaded singularity image to {}'.format(singularity_image_path))
-            return singularity_image_path
+    @classmethod
+    def get_singularity_image(cls, cfg, os_version, os_sha):
+        return os.path.join(
+            cfg.get('sys_image_dir', cls.DEFAULT_SYS_IMAGE_DIR),
+            'OpenStudio-{ver}.{sha}-Singularity.simg'.format(
+                ver=os_version,
+                sha=os_sha
+            )
+        )
 
     @property
     def weather_dir(self):

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -14,3 +14,11 @@ Development Changelog
         This is an example change. Please copy and paste it - for valid tags please refer to ``conf.py`` in the docs
         directory. ``pullreq`` should be set to the appropriate pull request number and ``tickets`` to any related
         github issues. These will be automatically linked in the documentation.
+
+    .. change::
+        :tags: bugfix
+        :pullreq: 386
+        :tickets: 256
+
+        No longer automatically downloads the appropriate singularity image from
+        S3. Also added validation to ensure the image is in the correct location.


### PR DESCRIPTION
Fixes #256.

## Pull Request Description

Instead of fixing the collision I'm just removing the "feature" that would download the singularity image to the run directory. It's better to know and make sure it's in the shared directory in the first place.

## Checklist

Not all may apply

- [x] Code changes (must work)
- [x] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [x] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/ci.yml` as necessary.
- [x] All other unit and integration tests passing
- [x] Update validation for project config yaml file changes
- [x] Update existing documentation
- [x] Run a small batch run on Eagle to make sure it all works if you made changes that will affect Eagle
- [x] Add to the changelog_dev.rst file and propose migration text in the pull request
