### PR TITLE
Fixing output directory validation on Eagle

### DIFF
--- a/buildstockbatch/eagle.py
+++ b/buildstockbatch/eagle.py
@@ -94,7 +94,7 @@ class EagleBatch(BuildStockBatchBase):
     def validate_output_directory_eagle(cls, project_file):
         cfg = get_project_configuration(project_file)
         output_dir = path_rel_to_file(project_file, cfg['output_directory'])
-        if not (output_dir.startswith('/scratch') or output_dir.startswith('/projects')):
+        if not re.match(r"/(lustre/eaglefs/)?(scratch|projects)", output_dir):
             raise ValidationError(f"`output_directory` must be in /scratch or /projects,"
                                   f" `output_directory` = {output_dir}")
 
@@ -102,7 +102,7 @@ class EagleBatch(BuildStockBatchBase):
     def validate_singularity_image_eagle(cls, project_file):
         cfg = get_project_configuration(project_file)
         singularity_image = cls.get_singularity_image(
-            cfg, 
+            cfg,
             cfg.get('os_version', cls.DEFAULT_OS_VERSION),
             cfg.get('os_sha', cls.DEFAULT_OS_SHA)
         )

--- a/buildstockbatch/test/test_validation.py
+++ b/buildstockbatch/test/test_validation.py
@@ -297,7 +297,13 @@ def test_validate_eagle_output_directory():
     with pytest.raises(ValidationError, match=r"must be in /scratch or /projects"):
         EagleBatch.validate_output_directory_eagle(str(minimal_yml))
     with tempfile.TemporaryDirectory() as tmpdir:
-        for output_directory in ('/scratch/username/out_dir', '/projects/projname/out_dir'):
+        dirs_to_try = [
+            '/scratch/username/out_dir',
+            '/projects/projname/out_dir',
+            '/lustre/eaglefs/scratch/username/out_dir',
+            '/lustre/eaglefs/projects/projname/out_dir'
+        ]
+        for output_directory in dirs_to_try:
             with open(minimal_yml, 'r') as f:
                 cfg = yaml.load(f, Loader=yaml.SafeLoader)
             cfg['output_directory'] = output_directory

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -51,3 +51,11 @@ Development Changelog
         :pullreq: 365
 
         Upload buildstock.csv to S3 during postprocessing
+
+    .. change::
+        :tags: eagle, bugfix
+        :tickets: 393
+        :pullreq: 397
+
+        Updating validation for Eagle output directory to include
+        ``/lustre/eaglefs`` directories.


### PR DESCRIPTION
Fixes #393.

## Pull Request Description

Allows output directories to start with ``/lustre/eaglefs`` on Eagle now. 

## Checklist

Not all may apply

- [x] Code changes (must work)
- [x] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [x] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/ci.yml` as necessary.
- [x] All other unit and integration tests passing
- [x] ~~Update validation for project config yaml file changes~~
- [x] ~~Update existing documentation~~
- [x] ~~Run a small batch run on Eagle to make sure it all works if you made changes that will affect Eagle~~
- [x] Add to the changelog_dev.rst file and propose migration text in the pull request
