### PR TITLE
remove always-added reporting measure from Comstock

### DIFF
--- a/buildstockbatch/workflow_generator/commercial.py
+++ b/buildstockbatch/workflow_generator/commercial.py
@@ -143,15 +143,6 @@ class CommercialDefaultWorkflowGenerator(WorkflowGeneratorBase):
                 list(map(lambda x: x['measure_dir_name'] == 'BuildExistingModel', osw['steps'])).index(True)
             osw['steps'].insert(build_existing_model_idx + 1, apply_upgrade_measure)
 
-        # Always-added reporting measures
-        osw['steps'].extend([
-            {
-                "measure_dir_name": "SimulationOutputReport",
-                "arguments": {},
-                "measure_type": "ReportingMeasure"
-            }
-        ])
-
         if 'timeseries_csv_export' in workflow_args:
             timeseries_csv_export_args = {
                 'reporting_frequency': 'Timestep',

--- a/buildstockbatch/workflow_generator/test_workflow_generator.py
+++ b/buildstockbatch/workflow_generator/test_workflow_generator.py
@@ -168,13 +168,13 @@ def test_com_default_workflow_generator_basic(mocker):
     osw_gen = CommercialDefaultWorkflowGenerator(cfg, 10)
     osw = osw_gen.create_osw(sim_id, building_id, upgrade_idx)
 
-    # Should always get SimulationOutputReport
-    reporting_measure_step = osw['steps'][1]
-    assert reporting_measure_step['measure_dir_name'] == 'SimulationOutputReport'
-    assert reporting_measure_step['arguments'] == {}
-    assert reporting_measure_step['measure_type'] == 'ReportingMeasure'
+    # Should always get BuildExistingModel
+    reporting_measure_step = osw['steps'][0]
+    assert reporting_measure_step['measure_dir_name'] == 'BuildExistingModel'
+    assert reporting_measure_step['arguments']['number_of_buildings_represented'] == 1
+    assert reporting_measure_step['measure_type'] == 'ModelMeasure'
     # Should not get TimeseriesCSVExport if excluded in args
-    assert len(osw['steps']) == 2
+    assert len(osw['steps']) == 1
 
 
 def test_com_default_workflow_generator_with_timeseries(mocker):
@@ -199,13 +199,13 @@ def test_com_default_workflow_generator_with_timeseries(mocker):
     osw_gen = CommercialDefaultWorkflowGenerator(cfg, 10)
     osw = osw_gen.create_osw(sim_id, building_id, upgrade_idx)
 
-    # Should always get SimulationOutputReport
-    reporting_measure_step = osw['steps'][1]
-    assert reporting_measure_step['measure_dir_name'] == 'SimulationOutputReport'
-    assert reporting_measure_step['measure_type'] == 'ReportingMeasure'
-    assert reporting_measure_step['arguments'] == {}
+    # Should always get BuildExistingModel
+    reporting_measure_step = osw['steps'][0]
+    assert reporting_measure_step['measure_dir_name'] == 'BuildExistingModel'
+    assert reporting_measure_step['arguments']['number_of_buildings_represented'] == 1
+    assert reporting_measure_step['measure_type'] == 'ModelMeasure'
     # Should get TimeseriesCSVExport if included in args
-    reporting_measure_step = osw['steps'][2]
+    reporting_measure_step = osw['steps'][1]
     assert reporting_measure_step['measure_dir_name'] == 'TimeseriesCSVExport'
     assert reporting_measure_step['measure_type'] == 'ReportingMeasure'
     assert reporting_measure_step['arguments']['reporting_frequency'] == 'Hourly'
@@ -268,21 +268,23 @@ def test_com_default_workflow_generator_extended(mocker):
     osw = osw_gen.create_osw(sim_id, building_id, upgrade_idx)
 
     # Should always get SimulationOutputReport
-    reporting_measure_step = osw['steps'][1]
+    reporting_measure_step = osw['steps'][3]
     assert reporting_measure_step['measure_dir_name'] == 'SimulationOutputReport'
     assert reporting_measure_step['measure_type'] == 'ReportingMeasure'
     assert reporting_measure_step['arguments'] == {}
+    # Should only be one instance of SimulationOutputReport
+    assert [d['measure_dir_name'] == 'SimulationOutputReport' for d in osw['steps']].count(True) == 1
     # Should get TimeseriesCSVExport if included in args
-    reporting_measure_step = osw['steps'][2]
+    reporting_measure_step = osw['steps'][1]
     assert reporting_measure_step['measure_dir_name'] == 'TimeseriesCSVExport'
     assert reporting_measure_step['measure_type'] == 'ReportingMeasure'
     assert reporting_measure_step['arguments']['reporting_frequency'] == 'Hourly'
     assert reporting_measure_step['arguments']['inc_output_variables'] == 'true'
     # Should have the openstudio report
-    reporting_measure_step = osw['steps'][3]
+    reporting_measure_step = osw['steps'][2]
     assert reporting_measure_step['measure_dir_name'] == 'f8e23017-894d-4bdf-977f-37e3961e6f42'
     assert reporting_measure_step['measure_type'] == 'ReportingMeasure'
     assert reporting_measure_step['arguments']['building_summary_section'] == 'true'
     assert reporting_measure_step['arguments']['schedules_overview_section'] == 'true'
     # Should have 1 workflow measure plus 9 reporting measures
-    assert len(osw['steps']) == 10
+    assert len(osw['steps']) == 9

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -59,3 +59,10 @@ Development Changelog
 
         Allow fractional ``eagle.minutes_per_sim`` for simulations that run less
         than a minute. Making that it a required input.
+
+    .. change::
+        :tags: comstock, workflow
+        :pullreq: 399
+
+        Remove default addition of SimulationOutputReport from ComStock workflow generator to avoid multiple instances
+        when also included in YML. SimulationOutputReport measure must be included in YML to be added to workflow.


### PR DESCRIPTION
SimulationOutputReport was being added to the comstock workflow by default, **as well as** when specified in the yml. This removes the default addition: SimulationOutputReport must be specified in the yml to be included in the workflow. 

Eyeballing from my recent profiling of a 10k run shows the second instance of SimulationOutputReport taking roughly 10% of the total workflow runtime.  