### PR TITLE
Removing /tmp/scratch files at end of array job

### DIFF
--- a/buildstockbatch/eagle.py
+++ b/buildstockbatch/eagle.py
@@ -61,7 +61,6 @@ class EagleBatch(BuildStockBatchBase):
     min_sims_per_job = 36 * 2
 
     local_scratch = pathlib.Path(os.environ.get("LOCAL_SCRATCH", "/tmp/scratch"))
-    local_project_dir = local_scratch / "project"
     local_buildstock_dir = local_scratch / "buildstock"
     local_weather_dir = local_scratch / "weather"
     local_output_dir = local_scratch / "output"
@@ -314,9 +313,7 @@ class EagleBatch(BuildStockBatchBase):
 
         # Remove local scratch files
         dirs_to_remove = [
-            self.local_project_dir,
             self.local_buildstock_dir,
-            self.local_weather_dir,
             self.local_weather_dir,
             self.local_output_dir,
             self.local_housing_characteristics_dir,
@@ -325,7 +322,10 @@ class EagleBatch(BuildStockBatchBase):
         logger.info(f"Cleaning up {self.local_scratch}")
         for dir in dirs_to_remove:
             logger.debug(f"Removing {dir}")
-            shutil.rmtree(dir)
+            if dir.exists():
+                shutil.rmtree(dir)
+            else:
+                logger.warning(f"Directory does not exist {dir}")
         logger.debug(f"Removing {self.local_singularity_img}")
         os.remove(self.local_singularity_img)
 

--- a/buildstockbatch/eagle.py
+++ b/buildstockbatch/eagle.py
@@ -312,6 +312,23 @@ class EagleBatch(BuildStockBatchBase):
 
         logger.info("batch complete")
 
+        # Remove local scratch files
+        dirs_to_remove = [
+            self.local_project_dir,
+            self.local_buildstock_dir,
+            self.local_weather_dir,
+            self.local_weather_dir,
+            self.local_output_dir,
+            self.local_housing_characteristics_dir,
+        ]
+
+        logger.info(f"Cleaning up {self.local_scratch}")
+        for dir in dirs_to_remove:
+            logger.debug(f"Removing {dir}")
+            shutil.rmtree(dir)
+        logger.debug(f"Removing {self.local_singularity_img}")
+        os.remove(self.local_singularity_img)
+
     @classmethod
     def run_building(cls, output_dir, cfg, n_datapoints, i, upgrade_idx=None):
         fs = LocalFileSystem()

--- a/buildstockbatch/eagle.py
+++ b/buildstockbatch/eagle.py
@@ -327,7 +327,7 @@ class EagleBatch(BuildStockBatchBase):
             else:
                 logger.warning(f"Directory does not exist {dir}")
         logger.debug(f"Removing {self.local_singularity_img}")
-        os.remove(self.local_singularity_img)
+        self.local_singularity_img.unlink(missing_ok=True)
 
     @classmethod
     def run_building(cls, output_dir, cfg, n_datapoints, i, upgrade_idx=None):

--- a/buildstockbatch/test/test_eagle.py
+++ b/buildstockbatch/test/test_eagle.py
@@ -256,7 +256,7 @@ def test_run_building_process(mocker, basic_residential_project_file):
         return joblib.Parallel(**kw2)
 
     mocker.patch("buildstockbatch.eagle.shutil.copy2")
-    mocker.patch("buildstockbatch.eagle.shutil.rmtree")
+    rmtree_mock = mocker.patch("buildstockbatch.eagle.shutil.rmtree")
     mocker.patch("buildstockbatch.eagle.Parallel", sequential_parallel)
     mocker.patch("buildstockbatch.eagle.subprocess")
 
@@ -288,6 +288,10 @@ def test_run_building_process(mocker, basic_residential_project_file):
     b.run_batch(sampling_only=True)  # so the directories can be created
     sampler_mock.run_sampling.assert_called_once()
     b.run_job_batch(1)
+    rmtree_mock.assert_any_call(b.local_buildstock_dir)
+    rmtree_mock.assert_any_call(b.local_weather_dir)
+    rmtree_mock.assert_any_call(b.local_output_dir)
+    rmtree_mock.assert_any_call(b.local_housing_characteristics_dir)
 
     # check results job-json
     refrence_path = pathlib.Path(__file__).resolve().parent / "test_results" / "reference_files"

--- a/buildstockbatch/test/test_eagle.py
+++ b/buildstockbatch/test/test_eagle.py
@@ -256,6 +256,7 @@ def test_run_building_process(mocker, basic_residential_project_file):
         return joblib.Parallel(**kw2)
 
     mocker.patch("buildstockbatch.eagle.shutil.copy2")
+    mocker.patch("buildstockbatch.eagle.shutil.rmtree")
     mocker.patch("buildstockbatch.eagle.Parallel", sequential_parallel)
     mocker.patch("buildstockbatch.eagle.subprocess")
 
@@ -341,6 +342,7 @@ def test_run_building_error_caught(mocker, basic_residential_project_file):
         return joblib.Parallel(**kw2)
 
     mocker.patch("buildstockbatch.eagle.shutil.copy2")
+    mocker.patch("buildstockbatch.eagle.shutil.rmtree")
     mocker.patch("buildstockbatch.eagle.Parallel", sequential_parallel)
     mocker.patch("buildstockbatch.eagle.subprocess")
 

--- a/create_eagle_env.sh
+++ b/create_eagle_env.sh
@@ -32,7 +32,7 @@ conda activate "$MY_CONDA_PREFIX"
 which pip
 if [ $DEV -eq 1 ]
 then
-    pip install --no-cache-dir -e .
+    pip install --no-cache-dir -e ".[dev]"
 else
     pip install --no-cache-dir .
 fi

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -14,3 +14,10 @@ Development Changelog
         This is an example change. Please copy and paste it - for valid tags please refer to ``conf.py`` in the docs
         directory. ``pullreq`` should be set to the appropriate pull request number and ``tickets`` to any related
         github issues. These will be automatically linked in the documentation.
+
+    .. change::
+        :tags: eagle, bugfix
+        :pullreq: 406
+        :tickets: 404
+
+        Cleans out the ``/tmp/scratch`` folder on Eagle at the end of each array job.


### PR DESCRIPTION
Fixes #404.

## Pull Request Description

At the request of the HPC team, we're cleaning up `/tmp/scratch` at the end of the job because their script is timing out and causing the nodes to fail and be pulled out of the pool. 

## Checklist

Not all may apply

- [x] Code changes (must work)
- [x] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [x] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/ci.yml` as necessary.
- [x] All other unit and integration tests passing
- [x] ~~Update validation for project config yaml file changes~~
- [x] ~~Update existing documentation~~
- [x] Run a small batch run on Eagle to make sure it all works if you made changes that will affect Eagle
- [x] Add to the changelog_dev.rst file and propose migration text in the pull request
