### PR TITLE
Fix CI workflow for PRs from other forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,14 +67,12 @@ jobs:
         with:
           name: coverage-report-html
           path: buildstockbatch/coverage/htmlreport/
-      - name: Report coverage to PR
-        uses: 5monkeys/cobertura-action@v13
+      - name: Save Coverage Report XML
+        uses: actions/upload-artifact@v3
         if: ${{ matrix.python-version == '3.11' }}
         with:
+          name: coverage-report-xml
           path: buildstockbatch/coverage/coverage.xml
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          minimum_coverage: 33
-          fail_below_threshold: true
       - name: Build documentation
         if: ${{ matrix.python-version == '3.11' }}
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,7 +35,6 @@ jobs:
         # https://github.com/5monkeys/cobertura-action/tree/master/.github/workflows
       - name: Report coverage to PR
         uses: 5monkeys/cobertura-action@v13
-        if: ${{ matrix.python-version == '3.11' }}
         with:
           path: buildstockbatch/coverage/coverage.xml
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,43 @@
+name: Coverage report
+
+on:
+  workflow_run:
+    workflows: ["BuildStockBatch Tests"]
+    types:
+      - completed
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_commit.id }}
+
+      - name: Download Coverage Artifacts
+        uses: Legit-Labs/action-download-artifact@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          workflow_conclusion: success
+          commit: ${{ github.event.workflow_run.head_commit.id }}
+          name: coverage-report-xml
+          path: buildstockbatch/coverage
+
+        # This step is here instead of in ci.yml because PRs from other forks
+        # do not have write permission to the PR during a pull_request action.
+        # More information:
+        # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+        # Example to follow:
+        # https://github.com/5monkeys/cobertura-action/tree/master/.github/workflows
+      - name: Report coverage to PR
+        uses: 5monkeys/cobertura-action@v13
+        if: ${{ matrix.python-version == '3.11' }}
+        with:
+          path: buildstockbatch/coverage/coverage.xml
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          minimum_coverage: 33
+          fail_below_threshold: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   coverage:
+    name: Post coverage report to PR
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.event == 'pull_request' }}
 


### PR DESCRIPTION
The CI workflow currently fails for pull requests from other forks because it only has read access to the repo (for good security reasons), which means it can't post comments/edits/updates to the PR.

This splits things into two separate workflows:
- CI workflow: Read-only because it executes code from the pull request, which could potentially be malicious. Runs tests and saves code coverage results.
- Coverage workflow: Has write access, but only the version on the default (`develop`) branch is run, and it doesn't execute any code from outside PRs. Reads the code coverage results and posts them as a comment on the PR.

See the links in the comments for more details about this setup.

I tested this on the rewiringamerica/buildstockbatch fork and confirmed that the coverage results were posted on PRs.
