### PR TITLE
Skip post-processing of upgrade directories that fail to list

### DIFF
--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -514,7 +514,14 @@ def combine_results(fs, results_dir, cfg, do_timeseries=True):
         if do_timeseries:
             # Get the names of the timeseries file for each simulation in this upgrade
             ts_upgrade_path = f"{ts_in_dir}/up{upgrade_id:02d}"
-            ts_filenames = [ts_upgrade_path + ts_filename for ts_filename in fs.ls(ts_upgrade_path)]
+            try:
+                ts_filenames = [ts_upgrade_path + ts_filename for ts_filename in fs.ls(ts_upgrade_path)]
+            except:
+                # Upgrade directories may be empty if the upgrade is invalid. In some cloud
+                # filesystems, there aren't actual directories, and trying to list a directory with
+                # no files in it can fail. Just continue post-processing (other upgrades).
+                logger.warning(f"Listing '{ts_upgrade_path}' failed. Skipping this upgrade.")
+                continue
             ts_bldg_ids = [int(re.search(r"bldg(\d+).parquet", flname).group(1)) for flname in ts_filenames]
             if not ts_filenames:
                 logger.warning(f"There are no timeseries files for upgrade{upgrade_id}.")

--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -516,7 +516,7 @@ def combine_results(fs, results_dir, cfg, do_timeseries=True):
             ts_upgrade_path = f"{ts_in_dir}/up{upgrade_id:02d}"
             try:
                 ts_filenames = [ts_upgrade_path + ts_filename for ts_filename in fs.ls(ts_upgrade_path)]
-            except:
+            except FileNotFoundError:
                 # Upgrade directories may be empty if the upgrade is invalid. In some cloud
                 # filesystems, there aren't actual directories, and trying to list a directory with
                 # no files in it can fail. Just continue post-processing (other upgrades).


### PR DESCRIPTION
### Background
* Upgrade directories may be empty if the upgrade is invalid.
* In some cloud filesystems, there aren't actual directories (including for [S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-folders.html) and [Google Cloud Storage](https://cloud.google.com/storage/docs/folders)). So, an "empty directory" means the directory doesn't exist and can't be listed.

### Problem
Trying to list an "empty" upgrade directory during post-processing (which can happen if the upgrade was invalid) fails with an exception for Google Cloud Storage.

### Fix
Treat a failure to list an upgrade directory during post-processing the same as when the directory is empty (i.e., skip it).

### Alternatives considered

1. **Create a fake directory**: This causes the directory listing to also include the fake directory itself, causing a different error (trying to read the directory as if it's a parquet file), and thus a change to also list only parquet files in the directory (i.e., requires a hack to handle the hack).

## Checklist

Not all may apply

- [x] Code changes (must work)
- [x] ~~Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)~~
- [x] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/ci.yml` as necessary.
- [x] All other unit and integration tests passing
- [x] ~~Update validation for project config yaml file changes~~
- [x] ~~Update existing documentation~~
- [x] ~~Run a small batch run on Eagle to make sure it all works if you made changes that will affect Eagle~~
- [x] ~~Add to the changelog_dev.rst file and propose migration text in the pull request~~
