### PR TITLE
Two small fixes

### DIFF
--- a/buildstockbatch/aws/aws.py
+++ b/buildstockbatch/aws/aws.py
@@ -1723,7 +1723,7 @@ class AwsBatch(DockerBatchBase):
                     logger.debug("Extracting {}".format(epw_filename))
                     f_out.write(gzip.decompress(f_gz.getvalue()))
 
-        cls.run_simulations(cfg, jobs_d, job_id, sim_dir, S3FileSystem(), bucket, prefix)
+        cls.run_simulations(cfg, jobs_d, job_id, sim_dir, S3FileSystem(), f"{bucket}/{prefix}")
 
 
 @log_error_details()

--- a/buildstockbatch/cloud/docker_base.py
+++ b/buildstockbatch/cloud/docker_base.py
@@ -252,7 +252,7 @@ class DockerBatchBase(BuildStockBatchBase):
         dpouts = []
         simulation_output_tar_filename = sim_dir.parent / "simulation_outputs.tar.gz"
         asset_dirs = os.listdir(sim_dir)
-        ts_output_dir = (f"{output_path}/results/simulation_output/timeseries",)
+        ts_output_dir = f"{output_path}/results/simulation_output/timeseries"
 
         with tarfile.open(str(simulation_output_tar_filename), "w:gz") as simout_tar:
             for building_id, upgrade_idx in jobs_d["batch"]:

--- a/buildstockbatch/test/test_docker_base.py
+++ b/buildstockbatch/test/test_docker_base.py
@@ -1,5 +1,6 @@
 """Tests for the DockerBatchBase class."""
 from fsspec.implementations.local import LocalFileSystem
+import gzip
 import json
 import os
 import pathlib
@@ -97,6 +98,12 @@ def test_get_epws_to_download():
 
 
 def test_run_simulations(basic_residential_project_file):
+    """
+    Test running a single batch of simulation.
+
+    This doesn't provide all the necessary inputs for the simulations to succeed, but it confirms that they are
+    attempted, that the output files are produced, and that intermediate files are cleaned up.
+    """
     jobs_d = {
         "job_num": 0,
         "n_datapoints": 10,
@@ -124,6 +131,14 @@ def test_run_simulations(basic_residential_project_file):
 
         output_dir = bucket / "test_prefix" / "results" / "simulation_output"
         assert sorted(os.listdir(output_dir)) == ["results_job0.json.gz", "simulations_job0.tar.gz"]
+
+        # Check that buildings 1 and 5 (specified in jobs_d) are in the results
+        with gzip.open(output_dir / "results_job0.json.gz", "r") as f:
+            results = json.load(f)
+        assert len(results) == 2
+        for building in results:
+            assert building["building_id"] in (1, 5)
+
         # Check that files were cleaned up correctly
         assert not os.listdir(sim_dir)
         os.chdir(old_cwd)


### PR DESCRIPTION
Fixes two small issues from #422 

## Pull Request Description

- Removes a stray comma
- Pass bucket/prefix as a single param (changed this in the test, but not aws.py)

## Checklist

Not all may apply

- [x] Code changes (must work)
- [ ] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [x] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/coverage.yml` as necessary.
- [x] All other unit and integration tests passing
- [ ] ~~Update validation for project config yaml file changes~~
- [ ] ~~Update existing documentation~~
- [ ] ~~Run a small batch run on Kestrel/Eagle to make sure it all works if you made changes that will affect Kestrel/Eagle~~
- [ ] ~~Add to the changelog_dev.rst file and propose migration text in the pull request~~
