### PR TITLE
handle empty data_point_out.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Download and Install OpenStudio
         run: |
           wget -q https://github.com/NREL/OpenStudio/releases/download/v3.7.0/OpenStudio-3.7.0+d5269793f1-Ubuntu-22.04-x86_64.deb
-          sudo apt install -y ./OpenStudio-3.7.0-rc1+211bb633b0-Ubuntu-22.04-x86_64.deb
+          sudo apt install -y ./OpenStudio-3.7.0+d5269793f1-Ubuntu-22.04-x86_64.deb
           openstudio openstudio_version
           which openstudio
       - name: Install buildstockbatch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           wget --quiet https://data.nrel.gov/system/files/156/BuildStock_TMY3_FIPS.zip
       - name: Download and Install OpenStudio
         run: |
-          wget -q https://github.com/NREL/OpenStudio/releases/download/v3.7.0-rc1/OpenStudio-3.7.0-rc1+211bb633b0-Ubuntu-22.04-x86_64.deb
+          wget -q https://github.com/NREL/OpenStudio/releases/download/v3.7.0/OpenStudio-3.7.0+d5269793f1-Ubuntu-22.04-x86_64.deb
           sudo apt install -y ./OpenStudio-3.7.0-rc1+211bb633b0-Ubuntu-22.04-x86_64.deb
           openstudio openstudio_version
           which openstudio

--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -42,6 +42,8 @@ def read_data_point_out_json(fs, reporting_measures, filename):
     try:
         with fs.open(filename, "r") as f:
             d = json.load(f)
+        if not d:
+            return None
     except (FileNotFoundError, json.JSONDecodeError):
         return None
     else:

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -20,3 +20,9 @@ Development Changelog
         :pullreq: 422
 
         Refactor AWS code so it can be shared by the upcoming GCP implementation.
+
+    .. change::
+        :tags: general, bugfix
+        :pullreq: 426
+
+        A bugfix for gracefully handling empty data_point_out.json files.


### PR DESCRIPTION
## Pull Request Description

Sometimes, data_point_out.json can be present, but empty. This leads to obscure error downstream (see screenshot). This PR fixes the issue by treating empty json as not present. 

<img width="1261" alt="MicrosoftTeams-image (2)" src="https://github.com/NREL/buildstockbatch/assets/12487392/289f1148-cd6a-4dad-99f0-87e2c59b7498">

## Checklist

Not all may apply

- [ ] Code changes (must work)
- [ ] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [ ] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/coverage.yml` as necessary.
- [ ] All other unit and integration tests passing
- [ ] Update validation for project config yaml file changes
- [ ] Update existing documentation
- [ ] Run a small batch run on Kestrel/Eagle to make sure it all works if you made changes that will affect Kestrel/Eagle
- [ ] Add to the changelog_dev.rst file and propose migration text in the pull request
