### PR TITLE
ResStock-HPXML: optional utility bill reporting arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,15 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11']
     name: Tests - Python ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: buildstockbatch
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: NREL/resstock
           path: resstock
           ref: develop
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Download weather

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,20 +56,20 @@ jobs:
           cd buildstockbatch
           pytest --junitxml=coverage/junit.xml --cov=buildstockbatch --cov-report=xml:coverage/coverage.xml --cov-report=html:coverage/htmlreport
       - name: Test Report
-        uses: mikepenz/action-junit-report@v3.5.2
+        uses: mikepenz/action-junit-report@v4
         if: ${{ matrix.python-version == '3.11' }}
         with:
           report_paths: buildstockbatch/coverage/junit.xml
           check_name: Testing Report
           fail_on_failure: true
       - name: Save Coverage Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ matrix.python-version == '3.11' }}
         with:
           name: coverage-report-html
           path: buildstockbatch/coverage/htmlreport/
       - name: Save Coverage Report XML
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ matrix.python-version == '3.11' }}
         with:
           name: coverage-report-xml
@@ -80,7 +80,7 @@ jobs:
           cd buildstockbatch/docs
           make html SPHINXOPTS="-W --keep-going -n"
       - name: Save Docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ matrix.python-version == '3.11' }}
         with:
           name: documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           cd buildstockbatch
           pytest --junitxml=coverage/junit.xml --cov=buildstockbatch --cov-report=xml:coverage/coverage.xml --cov-report=html:coverage/htmlreport
       - name: Test Report
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@v3.5.2
         if: ${{ matrix.python-version == '3.11' }}
         with:
           report_paths: buildstockbatch/coverage/junit.xml

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,13 +13,13 @@ jobs:
     if: ${{ github.event.workflow_run.event == 'pull_request' }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_commit.id }}
 
       - name: Download Coverage Artifacts
-        uses: Legit-Labs/action-download-artifact@v2
+        uses: Legit-Labs/action-download-artifact@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: ${{ github.event.workflow_run.workflow_id }}

--- a/buildstockbatch/workflow_generator/residential_hpxml.py
+++ b/buildstockbatch/workflow_generator/residential_hpxml.py
@@ -118,8 +118,6 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
             output_variables: list(include('output-var-spec'), required=False)
             include_annual_bills: bool(required=False)
             include_monthly_bills: bool(required=False)
-            register_annual_bills: bool(required=False)
-            register_monthly_bills: bool(required=False)
         output-var-spec:
             name: str(required=True)
         measure-spec:
@@ -432,29 +430,33 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
         measure_path = os.path.join(measures_dir, "ReportUtilityBills")
         util_bills_rep_args_avail = get_measure_arguments(os.path.join(measure_path, "measure.xml"))
 
+        # Annual bills
         if "include_annual_bills" in util_bills_rep_args_avail:
             util_bills_rep_args["include_annual_bills"] = True
             if "include_annual_bills" in sim_out_rep_args:
                 util_bills_rep_args["include_annual_bills"] = sim_out_rep_args["include_annual_bills"]
-                sim_out_rep_args.pop("include_annual_bills")
 
+        if "register_annual_bills" in util_bills_rep_args_avail:
+            util_bills_rep_args["register_annual_bills"] = True
+            if "include_annual_bills" in sim_out_rep_args:
+                util_bills_rep_args["register_annual_bills"] = sim_out_rep_args["include_annual_bills"]
+
+        if "include_annual_bills" in sim_out_rep_args:
+            sim_out_rep_args.pop("include_annual_bills")
+
+        # Monthly bills
         if "include_monthly_bills" in util_bills_rep_args_avail:
             util_bills_rep_args["include_monthly_bills"] = False
             if "include_monthly_bills" in sim_out_rep_args:
                 util_bills_rep_args["include_monthly_bills"] = sim_out_rep_args["include_monthly_bills"]
-                sim_out_rep_args.pop("include_monthly_bills")
 
-        if 'register_annual_bills' in util_bills_rep_args_avail:
-            util_bills_rep_args['register_annual_bills'] = True
-            if "register_annual_bills" in sim_out_rep_args:
-                util_bills_rep_args["register_annual_bills"] = sim_out_rep_args["register_annual_bills"]
-                sim_out_rep_args.pop("register_annual_bills")
+        if "register_monthly_bills" in util_bills_rep_args_avail:
+            util_bills_rep_args["register_monthly_bills"] = False
+            if "include_monthly_bills" in sim_out_rep_args:
+                util_bills_rep_args["register_monthly_bills"] = sim_out_rep_args["include_monthly_bills"]
 
-        if 'register_monthly_bills' in util_bills_rep_args_avail:
-            util_bills_rep_args['register_monthly_bills'] = False
-            if "register_monthly_bills" in sim_out_rep_args:
-                util_bills_rep_args["register_monthly_bills"] = sim_out_rep_args["register_monthly_bills"]
-                sim_out_rep_args.pop("register_monthly_bills")
+        if "include_monthly_bills" in sim_out_rep_args:
+            sim_out_rep_args.pop("include_monthly_bills")
 
         osw = {
             "id": sim_id,

--- a/buildstockbatch/workflow_generator/residential_hpxml.py
+++ b/buildstockbatch/workflow_generator/residential_hpxml.py
@@ -116,6 +116,10 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
             add_timeseries_dst_column: bool(required=False)
             add_timeseries_utc_column: bool(required=False)
             output_variables: list(include('output-var-spec'), required=False)
+            include_annual_bills: bool(required=False)
+            include_monthly_bills: bool(required=False)
+            register_annual_bills: bool(required=False)
+            register_monthly_bills: bool(required=False)
         output-var-spec:
             name: str(required=True)
         measure-spec:
@@ -430,9 +434,27 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
 
         if "include_annual_bills" in util_bills_rep_args_avail:
             util_bills_rep_args["include_annual_bills"] = True
+            if "include_annual_bills" in sim_out_rep_args:
+                util_bills_rep_args["include_annual_bills"] = sim_out_rep_args["include_annual_bills"]
+                sim_out_rep_args.pop("include_annual_bills")
 
         if "include_monthly_bills" in util_bills_rep_args_avail:
             util_bills_rep_args["include_monthly_bills"] = False
+            if "include_monthly_bills" in sim_out_rep_args:
+                util_bills_rep_args["include_monthly_bills"] = sim_out_rep_args["include_monthly_bills"]
+                sim_out_rep_args.pop("include_monthly_bills")
+
+        if 'register_annual_bills' in util_bills_rep_args_avail:
+            util_bills_rep_args['register_annual_bills'] = True
+            if "register_annual_bills" in sim_out_rep_args:
+                util_bills_rep_args["register_annual_bills"] = sim_out_rep_args["register_annual_bills"]
+                sim_out_rep_args.pop("register_annual_bills")
+
+        if 'register_monthly_bills' in util_bills_rep_args_avail:
+            util_bills_rep_args['register_monthly_bills'] = False
+            if "register_monthly_bills" in sim_out_rep_args:
+                util_bills_rep_args["register_monthly_bills"] = sim_out_rep_args["register_monthly_bills"]
+                sim_out_rep_args.pop("register_monthly_bills")
 
         osw = {
             "id": sim_id,

--- a/buildstockbatch/workflow_generator/test_workflow_generator.py
+++ b/buildstockbatch/workflow_generator/test_workflow_generator.py
@@ -129,6 +129,8 @@ def test_residential_hpxml(mocker):
     assert utility_bills_step["measure_dir_name"] == "ReportUtilityBills"
     assert utility_bills_step["arguments"]["include_annual_bills"] is True
     assert utility_bills_step["arguments"]["include_monthly_bills"] is False
+    assert utility_bills_step["arguments"]["register_annual_bills"] is True
+    assert utility_bills_step["arguments"]["register_monthly_bills"] is False
 
     upgrade_costs_step = steps[6]
     assert upgrade_costs_step["measure_dir_name"] == "UpgradeCosts"

--- a/buildstockbatch/workflow_generator/test_workflow_generator.py
+++ b/buildstockbatch/workflow_generator/test_workflow_generator.py
@@ -129,8 +129,6 @@ def test_residential_hpxml(mocker):
     assert utility_bills_step["measure_dir_name"] == "ReportUtilityBills"
     assert utility_bills_step["arguments"]["include_annual_bills"] is True
     assert utility_bills_step["arguments"]["include_monthly_bills"] is False
-    assert utility_bills_step["arguments"]["register_annual_bills"] is True
-    assert utility_bills_step["arguments"]["register_monthly_bills"] is False
 
     upgrade_costs_step = steps[6]
     assert upgrade_costs_step["measure_dir_name"] == "UpgradeCosts"

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -72,3 +72,10 @@ Development Changelog
         :pullreq: 450
 
         Requires ``os_version`` and ``os_sha`` in the project file.
+
+    .. change::
+        :tags: general, feature
+        :pullreq: 451
+
+        For the Residential HPXML Workflow Generator, exposes optional ``include_annual_bills`` and
+        ``include_monthly_bills`` arguments for reporting annual/monthly utility bill outputs.

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -78,4 +78,5 @@ Development Changelog
         :pullreq: 451
 
         For the Residential HPXML Workflow Generator, exposes optional ``include_annual_bills`` and
-        ``include_monthly_bills`` arguments for reporting annual/monthly utility bill outputs.
+        ``include_monthly_bills`` arguments for reporting annual and monthly utility bill outputs,
+        respectively.

--- a/docs/workflow_generators/residential_hpxml.rst
+++ b/docs/workflow_generators/residential_hpxml.rst
@@ -116,6 +116,10 @@ Arguments
   - ``add_timeseries_dst_column``: Optionally add, in addition to the default local standard Time column, a local clock TimeDST column. Requires that daylight saving time is enabled.
   - ``add_timeseries_utc_column``: Optionally add, in addition to the default local standard Time column, a local clock TimeUTC column. If the time zone UTC offset is not provided in the HPXML file, the time zone in the EPW header will be used.
   - ``output_variables``: Optionally request EnergyPlus output variables. Do not include key values; by default all key values will be requested.
+  - ``include_annual_bills``: Generates output file containing annual utility bills.
+  - ``include_monthly_bills``: Generates output file containing monthly utility bills.
+  - ``register_annual_bills``: Registers annual utility bills with the OpenStudio runner for downstream processing.
+  - ``register_monthly_bills``: Registers monthly utility bills with the OpenStudio runner for downstream processing.
 
 - ``reporting_measures`` (optional): A list of additional reporting measures to apply to the workflow.
   Any columns reported by these additional measures will be appended to the results csv.

--- a/docs/workflow_generators/residential_hpxml.rst
+++ b/docs/workflow_generators/residential_hpxml.rst
@@ -116,10 +116,8 @@ Arguments
   - ``add_timeseries_dst_column``: Optionally add, in addition to the default local standard Time column, a local clock TimeDST column. Requires that daylight saving time is enabled.
   - ``add_timeseries_utc_column``: Optionally add, in addition to the default local standard Time column, a local clock TimeUTC column. If the time zone UTC offset is not provided in the HPXML file, the time zone in the EPW header will be used.
   - ``output_variables``: Optionally request EnergyPlus output variables. Do not include key values; by default all key values will be requested.
-  - ``include_annual_bills``: Generates output file containing annual utility bills.
-  - ``include_monthly_bills``: Generates output file containing monthly utility bills.
-  - ``register_annual_bills``: Registers annual utility bills with the OpenStudio runner for downstream processing.
-  - ``register_monthly_bills``: Registers monthly utility bills with the OpenStudio runner for downstream processing.
+  - ``include_annual_bills``: Generates output file containing annual utility bills, and registers annual utility bills with the OpenStudio runner for downstream processing.
+  - ``include_monthly_bills``: Generates output file containing monthly utility bills, and registers monthly utility bills with the OpenStudio runner for downstream processing.
 
 - ``reporting_measures`` (optional): A list of additional reporting measures to apply to the workflow.
   Any columns reported by these additional measures will be appended to the results csv.

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setuptools.setup(
     package_data={"buildstockbatch": ["*.sh", "schemas/*.yaml"], "": ["LICENSE"]},
     install_requires=[
         "pyyaml",
-        "requests",
+        "requests!=2.32.0",
         "numpy",
         "pandas>=2",
         "joblib",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setuptools.setup(
     package_data={"buildstockbatch": ["*.sh", "schemas/*.yaml"], "": ["LICENSE"]},
     install_requires=[
         "pyyaml",
-        "requests!=2.32.0",
+        "requests<2.32.0",
         "numpy",
         "pandas>=2",
         "joblib",


### PR DESCRIPTION
## Pull Request Description

User now has the ability to optionally set utility bill reporting arguments:
- `include_annual_bills` (default: true)
- `include_monthly_bills` (default: false)

These will live under the `simulation_output_report` section of the yml file.

Argument `include_annual_bills=True` will generate `results_bills.csv` as well as register annual bills with the OpenStudio runner. Argument `include_monthly_bills` will generate `results_bills_monthly.csv` as well as register monthly bills with the OpenStudio runner.

(Related to https://github.com/NREL/resstock/pull/1246 and https://github.com/NREL/buildstockbatch/pull/383.)

## Checklist

Not all may apply

- [x] Code changes (must work)
- [ ] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [ ] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/coverage.yml` as necessary.
- [x] All other unit and integration tests passing
- [x] Update validation for project config yaml file changes
- [x] Update existing documentation
- [ ] ~Run a small batch run on Kestrel/Eagle to make sure it all works if you made changes that will affect Kestrel/Eagle~
- [x] Add to the changelog_dev.rst file and propose migration text in the pull request
