### PR TITLE
Updates kestrel node memory to request default nodes

### DIFF
--- a/buildstockbatch/hpc.py
+++ b/buildstockbatch/hpc.py
@@ -778,8 +778,8 @@ class KestrelBatch(SlurmBatch):
     HPC_NAME = "kestrel"
     CORES_PER_NODE = 104
     MIN_SIMS_PER_JOB = 104 * 2
-    DEFAULT_POSTPROCESSING_NODE_MEMORY_MB = 247000  # Standard node
-    DEFAULT_NODE_MEMORY_MB = 247000  # standard node on Kestrel
+    DEFAULT_POSTPROCESSING_NODE_MEMORY_MB = 246000  # Standard node on Kestrel as of 6/3/2024 HPC email
+    DEFAULT_NODE_MEMORY_MB = 246000  # Standard node on Kestrel as of 6/3/2024 HPC email
     DEFAULT_POSTPROCESSING_N_PROCS = 52
     DEFAULT_POSTPROCESSING_N_WORKERS = 2
 


### PR DESCRIPTION
On 6/3/2024 the NREL HPC team reduced the available memory on default nodes from 247,000 MB to 246,000 MB. Without this change, all buildstockbatch jobs will be put into the bigmem queue, which has only a handful of nodes.

## Pull Request Description

Changes the memory request on Kestrel to match the newly revised limit.

## Checklist

Not all may apply

- [ ] Code changes (must work)
- [ ] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [ ] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/coverage.yml` as necessary.
- [ ] All other unit and integration tests passing
- [ ] Update validation for project config yaml file changes
- [ ] Update existing documentation
- [ ] Run a small batch run on Kestrel/Eagle to make sure it all works if you made changes that will affect Kestrel/Eagle
- [ ] Add to the changelog_dev.rst file and propose migration text in the pull request
