### PR TITLE
ResStock-HPXML: convert UpgradeCosts measure to ModelMeasure

### DIFF
--- a/buildstockbatch/workflow_generator/residential_hpxml.py
+++ b/buildstockbatch/workflow_generator/residential_hpxml.py
@@ -40,6 +40,7 @@ def get_measure_arguments(xml_path):
             arguments.append(name)
     return arguments
 
+
 def get_measure_attributes(xml_path):
     attributes = {}
     if os.path.isfile(xml_path):
@@ -496,7 +497,6 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
                         "skip_validation": True,
                     },
                 },
-                
             ]
         )
 
@@ -504,10 +504,15 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
         measure_path = os.path.join(measures_dir, "UpgradeCosts")
         upg_costs_atts_avail = get_measure_attributes(os.path.join(measure_path, "measure.xml"))
 
-        if upg_costs_atts_avail["Measure Type"] == 'ModelMeasure':
+        if upg_costs_atts_avail["Measure Type"] == "ModelMeasure":
             osw["steps"].extend(
                 [
-                    {"measure_dir_name": "UpgradeCosts", "arguments": {"debug": debug}},
+                    {
+                        "measure_dir_name": "UpgradeCosts",
+                        "arguments": {
+                            "debug": debug,
+                        },
+                    },
                 ]
             )
 

--- a/buildstockbatch/workflow_generator/residential_hpxml.py
+++ b/buildstockbatch/workflow_generator/residential_hpxml.py
@@ -486,12 +486,8 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
                         "skip_validation": True,
                     },
                 },
-                {"measure_dir_name": "HPXMLOutput",
-                    "arguments": {}
-                },
-                {"measure_dir_name": "UpgradeCosts",
-                    "arguments": {"debug": debug}
-                }
+                {"measure_dir_name": "HPXMLOutput", "arguments": {}},
+                {"measure_dir_name": "UpgradeCosts", "arguments": {"debug": debug}},
             ]
         )
 

--- a/buildstockbatch/workflow_generator/residential_hpxml.py
+++ b/buildstockbatch/workflow_generator/residential_hpxml.py
@@ -489,7 +489,7 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
                 {"measure_dir_name": "HPXMLOutput",
                     "arguments": {}
                 },
-                {"measure_dir_name": "CostMultipliers",
+                {"measure_dir_name": "UpgradeCosts",
                     "arguments": {"debug": debug}
                 }
             ]

--- a/buildstockbatch/workflow_generator/residential_hpxml.py
+++ b/buildstockbatch/workflow_generator/residential_hpxml.py
@@ -485,6 +485,12 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
                         "add_component_loads": add_component_loads,
                         "skip_validation": True,
                     },
+                },
+                {"measure_dir_name": "HPXMLOutput",
+                    "arguments": {}
+                },
+                {"measure_dir_name": "CostMultipliers",
+                    "arguments": {"debug": debug}
                 }
             ]
         )
@@ -497,12 +503,10 @@ class ResidentialHpxmlWorkflowGenerator(WorkflowGeneratorBase):
                     "measure_dir_name": "ReportSimulationOutput",
                     "arguments": sim_out_rep_args,
                 },
-                {"measure_dir_name": "ReportHPXMLOutput", "arguments": {}},
                 {
                     "measure_dir_name": "ReportUtilityBills",
                     "arguments": util_bills_rep_args,
                 },
-                {"measure_dir_name": "UpgradeCosts", "arguments": {"debug": debug}},
                 {
                     "measure_dir_name": "ServerDirectoryCleanup",
                     "arguments": server_dir_cleanup_args,

--- a/buildstockbatch/workflow_generator/test_workflow_generator.py
+++ b/buildstockbatch/workflow_generator/test_workflow_generator.py
@@ -68,7 +68,7 @@ def test_residential_hpxml(mocker):
     osw = osw_gen.create_osw(sim_id, building_id, upgrade_idx)
 
     steps = osw["steps"]
-    assert len(steps) == 8
+    assert len(steps) == 7
 
     build_existing_model_step = steps[0]
     assert build_existing_model_step["measure_dir_name"] == "BuildExistingModel"
@@ -84,13 +84,10 @@ def test_residential_hpxml(mocker):
     hpxml_to_os_step = steps[2]
     assert hpxml_to_os_step["measure_dir_name"] == "HPXMLtoOpenStudio"
 
-    hpxml_output_step = steps[3]
-    assert hpxml_output_step["measure_dir_name"] == "HPXMLOutput"
-
-    upgrade_costs_step = steps[4]
+    upgrade_costs_step = steps[3]
     assert upgrade_costs_step["measure_dir_name"] == "UpgradeCosts"
 
-    simulation_output_step = steps[5]
+    simulation_output_step = steps[4]
     assert simulation_output_step["measure_dir_name"] == "ReportSimulationOutput"
     assert simulation_output_step["arguments"]["timeseries_frequency"] == "hourly"
     assert simulation_output_step["arguments"]["include_annual_total_consumptions"] is True
@@ -128,12 +125,12 @@ def test_residential_hpxml(mocker):
     assert simulation_output_step["arguments"]["add_timeseries_dst_column"] is True
     assert simulation_output_step["arguments"]["add_timeseries_utc_column"] is True
 
-    utility_bills_step = steps[6]
+    utility_bills_step = steps[5]
     assert utility_bills_step["measure_dir_name"] == "ReportUtilityBills"
     assert utility_bills_step["arguments"]["include_annual_bills"] is True
     assert utility_bills_step["arguments"]["include_monthly_bills"] is False
 
-    server_dir_cleanup_step = steps[7]
+    server_dir_cleanup_step = steps[6]
     assert server_dir_cleanup_step["measure_dir_name"] == "ServerDirectoryCleanup"
 
 

--- a/buildstockbatch/workflow_generator/test_workflow_generator.py
+++ b/buildstockbatch/workflow_generator/test_workflow_generator.py
@@ -84,7 +84,13 @@ def test_residential_hpxml(mocker):
     hpxml_to_os_step = steps[2]
     assert hpxml_to_os_step["measure_dir_name"] == "HPXMLtoOpenStudio"
 
-    simulation_output_step = steps[3]
+    hpxml_output_step = steps[3]
+    assert hpxml_output_step["measure_dir_name"] == "HPXMLOutput"
+
+    upgrade_costs_step = steps[4]
+    assert upgrade_costs_step["measure_dir_name"] == "UpgradeCosts"
+
+    simulation_output_step = steps[5]
     assert simulation_output_step["measure_dir_name"] == "ReportSimulationOutput"
     assert simulation_output_step["arguments"]["timeseries_frequency"] == "hourly"
     assert simulation_output_step["arguments"]["include_annual_total_consumptions"] is True
@@ -122,16 +128,10 @@ def test_residential_hpxml(mocker):
     assert simulation_output_step["arguments"]["add_timeseries_dst_column"] is True
     assert simulation_output_step["arguments"]["add_timeseries_utc_column"] is True
 
-    hpxml_output_step = steps[4]
-    assert hpxml_output_step["measure_dir_name"] == "ReportHPXMLOutput"
-
-    utility_bills_step = steps[5]
+    utility_bills_step = steps[6]
     assert utility_bills_step["measure_dir_name"] == "ReportUtilityBills"
     assert utility_bills_step["arguments"]["include_annual_bills"] is True
     assert utility_bills_step["arguments"]["include_monthly_bills"] is False
-
-    upgrade_costs_step = steps[6]
-    assert upgrade_costs_step["measure_dir_name"] == "UpgradeCosts"
 
     server_dir_cleanup_step = steps[7]
     assert server_dir_cleanup_step["measure_dir_name"] == "ServerDirectoryCleanup"


### PR DESCRIPTION
## Pull Request Description

UpgradeCosts has been changed from a reporting measure to a model measure (and ReportHPXMLOutput has been removed). Therefore, we need a few changes to the residential workflow generator. We also need to continue to support older versions of UpgradeCosts/ReportHPXMLOutput as reporting measures.

(Related to https://github.com/NREL/resstock/pull/1253.)

## Checklist

Not all may apply

- [ ] Code changes (must work)
- [ ] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [ ] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/coverage.yml` as necessary.
- [ ] All other unit and integration tests passing
- [ ] Update validation for project config yaml file changes
- [ ] Update existing documentation
- [ ] Run a small batch run on Kestrel/Eagle to make sure it all works if you made changes that will affect Kestrel/Eagle
- [ ] Add to the changelog_dev.rst file and propose migration text in the pull request
