### PR TITLE
Skip writing ts metadata since it causes timeout

### DIFF
--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -379,19 +379,6 @@ def write_metadata_files(fs, parquet_root_dir, partition_columns):
     parquet.write_metadata(sch, f"{parquet_root_dir}/_common_metadata", filesystem=fs)
     logger.info(f"Written _common_metadata to {parquet_root_dir}")
 
-    if partition_columns:
-        partition_glob = "/".join([f"{c}*" for c in partition_columns])
-        glob_str = f"{parquet_root_dir}/up*/{partition_glob}/*.parquet"
-    else:
-        glob_str = f"{parquet_root_dir}/up*/*.parquet"
-
-    logger.info(f"Gathering all the parquet files in {glob_str}")
-    concat_files = fs.glob(glob_str)
-    logger.info(f"Gathered {len(concat_files)} files. Now writing _metadata")
-    parquet_root_dir = Path(parquet_root_dir).as_posix()
-    create_metadata_file(concat_files, root_dir=parquet_root_dir, engine="pyarrow", fs=fs)
-    logger.info(f"_metadata file written to {parquet_root_dir}")
-
 
 def combine_results(fs, results_dir, cfg, do_timeseries=True):
     """Combine the results of the batch simulations.

--- a/buildstockbatch/test/test_base.py
+++ b/buildstockbatch/test/test_base.py
@@ -218,11 +218,6 @@ def test_upload_files(mocker, basic_residential_project_file):
     assert (source_file_path, s3_file_path) in files_uploaded
     files_uploaded.remove((source_file_path, s3_file_path))
 
-    s3_file_path = s3_path + "timeseries/_metadata"
-    source_file_path = os.path.join(source_path, "timeseries", "_metadata")
-    assert (source_file_path, s3_file_path) in files_uploaded
-    files_uploaded.remove((source_file_path, s3_file_path))
-
     s3_file_path = s3_path + "buildstock_csv/buildstock.csv"
     source_file_path = str(buildstock_csv_path)
     assert (source_file_path, s3_file_path) in files_uploaded

--- a/buildstockbatch/test/test_local.py
+++ b/buildstockbatch/test/test_local.py
@@ -89,7 +89,6 @@ def test_resstock_local_batch(project_filename):
             assert (upg["completed_status"] == "Success").all()
             assert upg.shape[0] == n_datapoints
     assert (ts_pq_path / "_common_metadata").exists()
-    assert (ts_pq_path / "_metadata").exists()
 
     shutil.rmtree(out_path)
 

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -102,3 +102,10 @@ Development Changelog
         exposes optional ``include_annual_bills`` (defaults to true) and
         ``include_monthly_bills`` (defaults to false) arguments for reporting annual
         and monthly utility bill outputs, respectively.
+
+    .. change::
+        :tags: general, bugfix
+        :pullreq: 464
+
+        Stop creating dask _metadata files for the timeseries parquet files since it crashes the
+        postprocessing.


### PR DESCRIPTION
## Pull Request Description

Dask parquet metadata files are auxiliary files that can help dask speed up read operation on a folder housing large number fo files. However, postprocessing have been crashing when trying to write this file. This PR removes this step so that postprocessing can complete successfully.  

Example of crash:

 ```
INFO:2024-08-13 08:39:11:buildstockbatch.postprocessing:Gathered 70441 files. Now writing _metadata
/kfs2/shared-projects/buildstock/envs/dev-pwhite-20240808/lib/python3.11/site-packages/distributed/client.py:3362: UserWarning: Sending large graph of size 16.78 MiB.
This may cause some slowdown.
Consider loading the data with Dask directly
or using futures or delayed objects to embed the data into the graph without repetition.
See also https://docs.dask.org/en/stable/best-practices.html#load-data-with-dask for more information.
  warnings.warn(
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/kfs2/shared-projects/buildstock/envs/dev-pwhite-20240808/lib/python3.11/site-packages/buildstockbatch/hpc.py", line 978, in <module>
    main()
  File "/kfs2/shared-projects/buildstock/envs/dev-pwhite-20240808/lib/python3.11/site-packages/buildstockbatch/utils.py", line 120, in run_with_error_capture
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/kfs2/shared-projects/buildstock/envs/dev-pwhite-20240808/lib/python3.11/site-packages/buildstockbatch/hpc.py", line 962, in main
    batch.process_results()
  File "/kfs2/shared-projects/buildstock/envs/dev-pwhite-20240808/lib/python3.11/site-packages/buildstockbatch/hpc.py", line 670, in process_results
    super().process_results(*args, **kwargs)
  File "/kfs2/shared-projects/buildstock/envs/dev-pwhite-20240808/lib/python3.11/site-packages/buildstockbatch/base.py", line 954, in process_results
    postprocessing.combine_results(fs, self.results_dir, self.cfg, do_timeseries=do_timeseries)
  File "/kfs2/shared-projects/buildstock/envs/dev-pwhite-20240808/lib/python3.11/site-packages/buildstockbatch/postprocessing.py", line 613, in combine_results
    write_metadata_files(fs, ts_dir, partition_columns)
  File "/kfs2/shared-projects/buildstock/envs/dev-pwhite-20240808/lib/python3.11/site-packages/buildstockbatch/postprocessing.py", line 392, in write_metadata_files
    create_metadata_file(concat_files, root_dir=parquet_root_dir, engine="pyarrow", fs=fs)
  File "/kfs2/shared-projects/buildstock/envs/dev-pwhite-20240808/lib/python3.11/site-packages/dask/dataframe/io/parquet/core.py", line 1193, in create_metadata_file
    out = out.compute(**compute_kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/kfs2/shared-projects/buildstock/envs/dev-pwhite-20240808/lib/python3.11/site-packages/dask/base.py", line 376, in compute
    (result,) = compute(self, traverse=False, **kwargs)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/kfs2/shared-projects/buildstock/envs/dev-pwhite-20240808/lib/python3.11/site-packages/dask/base.py", line 662, in compute
    results = schedule(dsk, keys, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/kfs2/shared-projects/buildstock/envs/dev-pwhite-20240808/lib/python3.11/site-packages/dask/dataframe/io/parquet/arrow.py", line 1912, in aggregate_metadata
    meta.write_metadata_file(fil)
^^^^^^^^^^^
  File "pyarrow/_parquet.pyx", line 1073, in pyarrow._parquet.FileMetaData.write_metadata_file
  File "pyarrow/error.pxi", line 92, in pyarrow.lib.check_status
OSError: Couldn't serialize thrift: Internal buffer size overflow when requesting a buffer of size 4294967329
```

## Checklist

Not all may apply

- [x] Code changes (must work)
- [x] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [x] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/coverage.yml` as necessary.
- [x] All other unit and integration tests passing
- [x] Update validation for project config yaml file changes
- [x] Update existing documentation
- [x] Run a small batch run on Kestrel/Eagle to make sure it all works if you made changes that will affect Kestrel/Eagle
- [x] Add to the changelog_dev.rst file and propose migration text in the pull request
