### PR TITLE
Apptainer mount fix for ResStock and OpenStudio 3.8

### DIFF
--- a/buildstockbatch/hpc.py
+++ b/buildstockbatch/hpc.py
@@ -356,18 +356,14 @@ class SlurmBatch(BuildStockBatchBase):
                     cls.local_buildstock_dir / "measures",
                     cls.local_weather_dir,
                 ]
+                if (resources_dir := cls.local_buildstock_dir / "resources").exists():
+                    dirs_to_mount.append(resources_dir)
 
                 for src in dirs_to_mount:
                     container_mount = "/" + src.name
                     args.extend(["-B", "{}:{}:ro".format(src, container_mount)])
                     container_symlink = pathlib.Path("/var/simdata/openstudio", src.name)
                     runscript.append("ln -s {} {}".format(*map(shlex.quote, (container_mount, str(container_symlink)))))
-
-                if (cls.local_buildstock_dir / "resources" / "hpxml-measures").exists():
-                    runscript.append("ln -s /resources /var/simdata/openstudio/resources")
-                    src = cls.local_buildstock_dir / "resources" / "hpxml-measures"
-                    container_mount = "/resources/hpxml-measures"
-                    args.extend(["-B", f"{src}:{container_mount}:ro"])
 
                 # Build the openstudio command that will be issued within the
                 # apptainer container If custom gems are to be used in the

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -109,3 +109,11 @@ Development Changelog
 
         Stop creating dask _metadata files for the timeseries parquet files since it crashes the
         postprocessing.
+
+    .. change::
+        :tags: bugfix, hpc
+        :pullreq: 467
+
+        Updates the bind mount for apptainer to include the whole resources
+        directory instead of just the hpxml-measures directory. Makes it work
+        with newer versions of ResStock.


### PR DESCRIPTION
## Pull Request Description

In ResStock with OpenStudio 3.8 the BuildExistingModel measure is [trying to access the buildstock.rb file](https://github.com/NREL/resstock/blob/91f6f56a823e035e583dd5b78468ea19b248f79d/measures/BuildExistingModel/measure.rb#L8) in the resources directory using a relative path. We weren't mounting that in in apptainer, but just the hpxml-measures subdirectory. This should fix that.

## Checklist

Not all may apply

- [x] Code changes (must work)
- [x] ~~Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)~~
- [x] ~~Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/coverage.yml` as necessary.~~
- [x] All other unit and integration tests passing
- [x] ~~Update validation for project config yaml file changes~~
- [x] ~~Update existing documentation~~
- [x] Run a small batch run on Kestrel/Eagle to make sure it all works if you made changes that will affect Kestrel/Eagle
- [x] Add to the changelog_dev.rst file and propose migration text in the pull request
