### PR TITLE
Fix concurrency entry for coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,7 +7,7 @@ on:
       - completed
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.id }}
   cancel-in-progress: true
 
 jobs:
@@ -25,7 +25,7 @@ jobs:
       - name: Download Coverage Artifacts
         uses: Legit-Labs/action-download-artifact@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GHB_TOKEN }}
           workflow: ${{ github.event.workflow_run.workflow_id }}
           workflow_conclusion: success
           commit: ${{ github.event.workflow_run.head_commit.id }}
@@ -42,6 +42,6 @@ jobs:
         uses: 5monkeys/cobertura-action@v13
         with:
           path: buildstockbatch/coverage/coverage.xml
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ secrets.GHB_TOKEN }}
           minimum_coverage: 33
           fail_below_threshold: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Download Coverage Artifacts
         uses: Legit-Labs/action-download-artifact@v2
         with:
-          github_token: ${{ secrets.GHB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: ${{ github.event.workflow_run.workflow_id }}
           workflow_conclusion: success
           commit: ${{ github.event.workflow_run.head_commit.id }}
@@ -42,6 +42,6 @@ jobs:
         uses: 5monkeys/cobertura-action@v13
         with:
           path: buildstockbatch/coverage/coverage.xml
-          repo_token: ${{ secrets.GHB_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           minimum_coverage: 33
           fail_below_threshold: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,25 +23,28 @@ jobs:
           ref: ${{ github.event.workflow_run.head_commit.id }}
 
       - name: Download Coverage Artifacts
-        uses: Legit-Labs/action-download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: ${{ github.event.workflow_run.workflow_id }}
-          workflow_conclusion: success
-          commit: ${{ github.event.workflow_run.head_commit.id }}
+          run-id: ${{ github.event.workflow_run.id }}
           name: coverage-report-xml
           path: buildstockbatch/coverage
 
-        # This step is here instead of in ci.yml because PRs from other forks
-        # do not have write permission to the PR during a pull_request action.
-        # More information:
-        # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-        # Example to follow:
-        # https://github.com/5monkeys/cobertura-action/tree/master/.github/workflows
       - name: Report coverage to PR
-        uses: 5monkeys/cobertura-action@v13
+        uses: irongut/CodeCoverageSummary@v1.3.0
         with:
-          path: buildstockbatch/coverage/coverage.xml
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          minimum_coverage: 33
-          fail_below_threshold: true
+          filename: buildstockbatch/coverage/coverage.xml
+          badge: true
+          fail_below_min: true
+          format: markdown
+          hide_branch_rate: false
+          hide_complexity: true
+          indicators: true
+          output: both
+          thresholds: '33 75'
+
+      - name: Add Coverage PR Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event.workflow_run.event == 'pull_request'
+        with:
+          recreate: true
+          path: code-coverage-results.md


### PR DESCRIPTION
Coverage report has been broken for a while. This is an attempt to fix it. 

## Pull Request Description

description here

## Checklist

Not all may apply

- [ ] Code changes (must work)
- [ ] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [ ] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/coverage.yml` as necessary.
- [ ] All other unit and integration tests passing
- [ ] Update validation for project config yaml file changes
- [ ] Update existing documentation
- [ ] Run a small batch run on Kestrel to make sure it all works if you made changes that will affect Kestrel
- [ ] Add to the changelog_dev.rst file and propose migration text in the pull request
