### PR TITLE
Add flag to replace existing files in s3

### DIFF
--- a/buildstockbatch/base.py
+++ b/buildstockbatch/base.py
@@ -942,7 +942,7 @@ class BuildStockBatchBase(object):
     def upload_results(self, *args, **kwargs):
         return postprocessing.upload_results(*args, **kwargs)
 
-    def process_results(self, skip_combine=False, use_dask_cluster=True, continue_upload=False):
+    def process_results(self, skip_combine=False, use_dask_cluster=True, continue_upload=False, replace_existing=False):
         if use_dask_cluster:
             self.get_dask_client()  # noqa F841
 
@@ -963,7 +963,12 @@ class BuildStockBatchBase(object):
             aws_conf = self.cfg.get("postprocessing", {}).get("aws", {})
             if "s3" in aws_conf or "aws" in self.cfg:
                 s3_bucket, s3_prefix = self.upload_results(
-                    aws_conf, self.output_dir, self.results_dir, self.sampler.csv_path, continue_upload=continue_upload
+                    aws_conf,
+                    self.output_dir,
+                    self.results_dir,
+                    self.sampler.csv_path,
+                    continue_upload=continue_upload,
+                    replace_existing=replace_existing,
                 )
                 if "athena" in aws_conf:
                     postprocessing.create_athena_tables(

--- a/buildstockbatch/hpc.py
+++ b/buildstockbatch/hpc.py
@@ -579,9 +579,7 @@ class SlurmBatch(BuildStockBatchBase):
         job_id = m.group(1)
         return [job_id]
 
-    def queue_post_processing(
-        self, after_jobids=[], upload_only=False, hipri=False, continue_upload=False, replace_existing=False
-    ):
+    def queue_post_processing(self, after_jobids=[], upload_only=False, hipri=False, continue_upload=False):
         # Configuration values
         hpc_cfg = self.cfg[self.HPC_NAME]
         account = hpc_cfg["account"]
@@ -595,13 +593,10 @@ class SlurmBatch(BuildStockBatchBase):
         if not (upload_only or continue_upload):
             for subdir in ("parquet", "results_csvs"):
                 subdirpath = pathlib.Path(self.output_dir, "results", subdir)
-                if subdirpath.exists() and not replace_existing:
+                if subdirpath.exists():
                     raise FileExistsError(
                         f"{subdirpath} already exists. This means you may have run postprocessing already. If you are sure you want to rerun, delete that directory and try again."
                     )  # noqa E501
-                elif subdirpath.exists() and replace_existing:
-                    logger.info(f"Removing {subdirpath} to make way for new postprocessing.")
-                    shutil.rmtree(subdirpath)
 
         # Move old output logs and config to make way for new ones
         for filename in (
@@ -623,7 +618,6 @@ class SlurmBatch(BuildStockBatchBase):
             "OUT_DIR": self.output_dir,
             "UPLOADONLY": str(upload_only),
             "CONTINUE_UPLOAD": str(continue_upload),
-            "REPLACE_EXISTING": str(replace_existing),
             "MEMORY": str(memory),
             "NPROCS": str(n_procs),
         }
@@ -861,11 +855,6 @@ def user_cli(Batch: SlurmBatch, argv: list):
         action="store_true",
     )
     group.add_argument(
-        "--replace_existing",
-        help="Replace existing files in S3, useful when previous upload was interrupted.",
-        action="store_true",
-    )
-    group.add_argument(
         "--validateonly",
         help="Only validate the project YAML file and references. Nothing is executed",
         action="store_true",
@@ -887,14 +876,9 @@ def user_cli(Batch: SlurmBatch, argv: list):
         return
 
     # if the project has already been run, simply queue the correct post-processing step
-    if args.postprocessonly or args.uploadonly or args.continue_upload or args.replace_existing:
+    if args.postprocessonly or args.uploadonly or args.continue_upload:
         batch = Batch(project_filename)
-        batch.queue_post_processing(
-            upload_only=args.uploadonly,
-            hipri=args.hipri,
-            continue_upload=args.continue_upload,
-            replace_existing=args.replace_existing,
-        )
+        batch.queue_post_processing(upload_only=args.uploadonly, hipri=args.hipri, continue_upload=args.continue_upload)
         return
 
     if args.rerun_failed:
@@ -940,7 +924,6 @@ def main():
     post_process = get_bool_env_var("POSTPROCESS")
     upload_only = get_bool_env_var("UPLOADONLY")
     continue_upload = get_bool_env_var("CONTINUE_UPLOAD")
-    replace_existing = get_bool_env_var("REPLACE_EXISTING")
     measures_only = get_bool_env_var("MEASURESONLY")
     sampling_only = get_bool_env_var("SAMPLINGONLY")
     if job_array_number:
@@ -958,8 +941,6 @@ def main():
             batch.process_results(skip_combine=True)
         elif continue_upload:
             batch.process_results(skip_combine=True, continue_upload=True)
-        elif replace_existing:
-            batch.process_results(skip_combine=True, replace_existing=True)
         else:
             batch.process_results()
     else:

--- a/buildstockbatch/hpc.py
+++ b/buildstockbatch/hpc.py
@@ -579,7 +579,9 @@ class SlurmBatch(BuildStockBatchBase):
         job_id = m.group(1)
         return [job_id]
 
-    def queue_post_processing(self, after_jobids=[], upload_only=False, hipri=False, continue_upload=False):
+    def queue_post_processing(
+        self, after_jobids=[], upload_only=False, hipri=False, continue_upload=False, replace_existing=False
+    ):
         # Configuration values
         hpc_cfg = self.cfg[self.HPC_NAME]
         account = hpc_cfg["account"]
@@ -593,10 +595,13 @@ class SlurmBatch(BuildStockBatchBase):
         if not (upload_only or continue_upload):
             for subdir in ("parquet", "results_csvs"):
                 subdirpath = pathlib.Path(self.output_dir, "results", subdir)
-                if subdirpath.exists():
+                if subdirpath.exists() and not replace_existing:
                     raise FileExistsError(
                         f"{subdirpath} already exists. This means you may have run postprocessing already. If you are sure you want to rerun, delete that directory and try again."
                     )  # noqa E501
+                elif subdirpath.exists() and replace_existing:
+                    logger.info(f"Removing {subdirpath} to make way for new postprocessing.")
+                    shutil.rmtree(subdirpath)
 
         # Move old output logs and config to make way for new ones
         for filename in (
@@ -618,6 +623,7 @@ class SlurmBatch(BuildStockBatchBase):
             "OUT_DIR": self.output_dir,
             "UPLOADONLY": str(upload_only),
             "CONTINUE_UPLOAD": str(continue_upload),
+            "REPLACE_EXISTING": str(replace_existing),
             "MEMORY": str(memory),
             "NPROCS": str(n_procs),
         }
@@ -855,6 +861,11 @@ def user_cli(Batch: SlurmBatch, argv: list):
         action="store_true",
     )
     group.add_argument(
+        "--replace_existing",
+        help="Replace existing files in S3, useful when previous upload was interrupted.",
+        action="store_true",
+    )
+    group.add_argument(
         "--validateonly",
         help="Only validate the project YAML file and references. Nothing is executed",
         action="store_true",
@@ -876,9 +887,14 @@ def user_cli(Batch: SlurmBatch, argv: list):
         return
 
     # if the project has already been run, simply queue the correct post-processing step
-    if args.postprocessonly or args.uploadonly or args.continue_upload:
+    if args.postprocessonly or args.uploadonly or args.continue_upload or args.replace_existing:
         batch = Batch(project_filename)
-        batch.queue_post_processing(upload_only=args.uploadonly, hipri=args.hipri, continue_upload=args.continue_upload)
+        batch.queue_post_processing(
+            upload_only=args.uploadonly,
+            hipri=args.hipri,
+            continue_upload=args.continue_upload,
+            replace_existing=args.replace_existing,
+        )
         return
 
     if args.rerun_failed:
@@ -924,6 +940,7 @@ def main():
     post_process = get_bool_env_var("POSTPROCESS")
     upload_only = get_bool_env_var("UPLOADONLY")
     continue_upload = get_bool_env_var("CONTINUE_UPLOAD")
+    replace_existing = get_bool_env_var("REPLACE_EXISTING")
     measures_only = get_bool_env_var("MEASURESONLY")
     sampling_only = get_bool_env_var("SAMPLINGONLY")
     if job_array_number:
@@ -941,6 +958,8 @@ def main():
             batch.process_results(skip_combine=True)
         elif continue_upload:
             batch.process_results(skip_combine=True, continue_upload=True)
+        elif replace_existing:
+            batch.process_results(skip_combine=True, replace_existing=True)
         else:
             batch.process_results()
     else:

--- a/buildstockbatch/local.py
+++ b/buildstockbatch/local.py
@@ -451,7 +451,7 @@ def main():
     elif args.continue_upload:
         batch.process_results(skip_combine=True, continue_upload=True)
     elif args.replace_existing:
-        batch.process_results(skip_combine=True, replace_existing=True)
+        batch.process_results(skip_combine=False, replace_existing=True)
     else:
         batch.process_results()
 

--- a/buildstockbatch/local.py
+++ b/buildstockbatch/local.py
@@ -418,6 +418,11 @@ def main():
         action="store_true",
     )
     group.add_argument(
+        "--replace_existing",
+        help="Replace existing files in S3 / output folder if they exist instead of erroring out.",
+        action="store_true",
+    )
+    group.add_argument(
         "--validateonly",
         help="Only validate the project YAML file and references. Nothing is executed",
         action="store_true",
@@ -445,6 +450,8 @@ def main():
         batch.process_results(skip_combine=True)
     elif args.continue_upload:
         batch.process_results(skip_combine=True, continue_upload=True)
+    elif args.replace_existing:
+        batch.process_results(skip_combine=True, replace_existing=True)
     else:
         batch.process_results()
 

--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -42,6 +42,7 @@ MAX_REPLACE_FILES = 9999  # maximum number of files to replace in s3 when using 
 # 1. It is inefficient
 # 2. It is easy to make mistakes and wipe out a significant run
 
+
 def read_data_point_out_json(fs, reporting_measures, filename):
     try:
         with fs.open(filename, "r") as f:

--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -669,7 +669,9 @@ def remove_intermediate_files(fs, results_dir, keep_individual_timeseries=False)
         fs.rm(ts_in_dir, recursive=True)
 
 
-def upload_results(aws_conf, output_dir, results_dir, buildstock_csv_filename, continue_upload=False):
+def upload_results(
+    aws_conf, output_dir, results_dir, buildstock_csv_filename, continue_upload=False, replace_existing=False
+):
     logger.info("Uploading the parquet files to s3")
 
     output_folder_name = Path(output_dir).name
@@ -698,8 +700,12 @@ def upload_results(aws_conf, output_dir, results_dir, buildstock_csv_filename, c
 
     if len(existing_files) > 0:
         logger.info(f"There are already {len(existing_files)} files in the s3 folder {s3_bucket}/{s3_prefix_output}.")
-        if not continue_upload:
-            raise FileExistsError("Either use --continue_upload or delete files from s3")
+        if not continue_upload and not replace_existing:
+            raise FileExistsError("Either use --continue_upload or --replace_existing or delete files from s3")
+        if replace_existing:
+            bucket.objects.filter(Prefix=s3_prefix_output).delete()
+            logger.info(f"Deleted {len(existing_files)} files from s3 folder {s3_bucket}/{s3_prefix_output}.")
+            existing_files = set()
         all_files = [file for file in all_files if str(file) not in existing_files]
         logger.info(f"Only uploading the rest of the {len(all_files)} files")
 

--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -709,7 +709,7 @@ def upload_results(
         if replace_existing and len(existing_files) > MAX_REPLACE_FILES:
             raise FileExistsError(
                 f"{len(existing_files)} files exist in s3://{s3_bucket}/{s3_prefix_output} folder."
-                "Can't replace more than {MAX_REPLACE_FILES} files."
+                f"Can't replace more than {MAX_REPLACE_FILES} files."
             )
         if replace_existing:
             bucket.objects.filter(Prefix=s3_prefix_output).delete()

--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -37,7 +37,7 @@ import polars as pl
 logger = logging.getLogger(__name__)
 
 MAX_PARQUET_MEMORY = 1000  # maximum size (MB) of the parquet file in memory when combining multiple parquets
-MAX_REPLACE_FILES = 999  # maximum number of files to replace in s3 when using --replace_existing. We don't
+MAX_REPLACE_FILES = 9999  # maximum number of files to replace in s3 when using --replace_existing. We don't
 # want to automatically delete large number of files using current API for two reasons:
 # 1. It is inefficient
 # 2. It is easy to make mistakes and wipe out a significant run

--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -37,7 +37,10 @@ import polars as pl
 logger = logging.getLogger(__name__)
 
 MAX_PARQUET_MEMORY = 1000  # maximum size (MB) of the parquet file in memory when combining multiple parquets
-
+MAX_REPLACE_FILES = 999  # maximum number of files to replace in s3 when using --replace_existing. We don't
+# want to automatically delete large number of files using current API for two reasons:
+# 1. It is inefficient
+# 2. It is easy to make mistakes and wipe out a significant run
 
 def read_data_point_out_json(fs, reporting_measures, filename):
     try:
@@ -702,12 +705,18 @@ def upload_results(
         logger.info(f"There are already {len(existing_files)} files in the s3 folder {s3_bucket}/{s3_prefix_output}.")
         if not continue_upload and not replace_existing:
             raise FileExistsError("Either use --continue_upload or --replace_existing or delete files from s3")
+        if replace_existing and len(existing_files) > MAX_REPLACE_FILES:
+            raise FileExistsError(
+                f"{len(existing_files)} files exist in s3://{s3_bucket}/{s3_prefix_output} folder."
+                "Can't replace more than {MAX_REPLACE_FILES} files."
+            )
         if replace_existing:
             bucket.objects.filter(Prefix=s3_prefix_output).delete()
-            logger.info(f"Deleted {len(existing_files)} files from s3 folder {s3_bucket}/{s3_prefix_output}.")
-            existing_files = set()
-        all_files = [file for file in all_files if str(file) not in existing_files]
-        logger.info(f"Only uploading the rest of the {len(all_files)} files")
+            logger.info(f"Deleted {len(existing_files)} files from s3://{s3_bucket}/{s3_prefix_output} folder.")
+            logger.info(f"Now uploading all {len(all_files)} files.")
+        else:
+            all_files = [file for file in all_files if str(file) not in existing_files]
+            logger.info(f"Only uploading the rest of the {len(all_files)} files")
 
     def upload_file(filepath, s3key=None):
         full_path = filepath if filepath.is_absolute() else parquet_dir.joinpath(filepath)

--- a/buildstockbatch/test/test_inputs/complete-schema.yml
+++ b/buildstockbatch/test/test_inputs/complete-schema.yml
@@ -1,6 +1,6 @@
 os_version: asdf
 os_sha: asdf
-buildstock_directory: /home/epresent/OpenStudio-BuildStock-master
+buildstock_directory: test_openstudio_buildstock
 project_directory: project_singlefamilydetached
 output_directory: /scratch/epresent/yaml1s
 weather_files_path: /shared-projects/buildstock/weather/project_resstock_national_weather.zip

--- a/buildstockbatch/test/test_postprocessing.py
+++ b/buildstockbatch/test/test_postprocessing.py
@@ -5,7 +5,6 @@ import logging
 import os
 import pathlib
 import re
-import tarfile
 import pytest
 import shutil
 import sys
@@ -197,3 +196,73 @@ def test_publish_annual_results(basic_residential_project_file, mocker):
         upgrade_id = int(upgrade_folder.name.split("=")[1])
         expected_file = upgrade_folder / f"results_up{upgrade_id:02d}.parquet"
         assert expected_file.exists(), f"Expected parquet file missing for {upgrade_folder.name}"
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        {"replace_existing": True, "continue_upload": False, "should_raise_error": False},
+        {"replace_existing": False, "continue_upload": False, "should_raise_error": True},
+        {"replace_existing": False, "continue_upload": True, "should_raise_error": False},
+    ],
+)
+def test_replace_existing(basic_residential_project_file, mocker, scenario):
+    """Test the replace_existing functionality."""
+    # Set up a mock S3 environment
+    mocker.patch("s3fs.S3FileSystem", new=mocker.MagicMock())
+    mocker.patch("boto3.resource", new=mocker.MagicMock())
+
+    # Create a basic residential project file
+    project_filename, results_dir = basic_residential_project_file(
+        {"postprocessing": {"aws": {"s3": {"bucket": "dummy", "prefix": "dummy"}}}}
+    )
+
+    # Mock the necessary objects
+    mocker.patch.object(BuildStockBatchBase, "weather_dir", None)
+    mocker.patch.object(BuildStockBatchBase, "get_dask_client")
+    mocker.patch.object(BuildStockBatchBase, "results_dir", results_dir)
+
+    # Create an instance of BuildStockBatchBase
+    bsb = BuildStockBatchBase(project_filename)
+
+    # Create some dummy result files
+    results_path = pathlib.Path(results_dir)
+    sim_out_dir = results_path / "simulation_output"
+    sim_out_dir.mkdir(parents=True, exist_ok=True)
+    (sim_out_dir / "results_job0.json.gz").touch()
+    parquet_dir = results_path / "parquet"
+    parquet_dir.mkdir(parents=True, exist_ok=True)
+
+    # Mock the S3 filesystem and existing files
+    mock_s3_resource = mocker.patch("boto3.resource").return_value
+    mock_bucket = mock_s3_resource.Bucket.return_value
+    mock_objects_filter_return_value = mocker.MagicMock()
+    mock_objects_filter_return_value.delete.return_value = None
+    mock_bucket.objects.filter.return_value = mock_objects_filter_return_value
+    mock_objects_filter_return_value.__iter__.return_value = [mocker.MagicMock(key="dummy/path/results.csv.gz")]
+
+    if scenario["should_raise_error"]:
+        with pytest.raises(FileExistsError):
+            bsb.upload_results(
+                aws_conf=bsb.cfg.get("postprocessing", {}).get("aws", {}),
+                output_dir=results_dir,
+                results_dir=results_dir,
+                buildstock_csv_filename=None,
+                replace_existing=scenario["replace_existing"],
+                continue_upload=scenario["continue_upload"],
+            )
+    else:
+        bsb.upload_results(
+            aws_conf=bsb.cfg.get("postprocessing", {}).get("aws", {}),
+            output_dir=results_dir,
+            results_dir=results_dir,
+            buildstock_csv_filename=None,
+            replace_existing=scenario["replace_existing"],
+            continue_upload=scenario["continue_upload"],
+        )
+        if scenario["replace_existing"]:
+            # Assert that the mock S3's rm method was called, which means files are being replaced
+            mock_bucket.objects.filter.return_value.delete.assert_called()
+        else:
+            # Assert that the mock S3's rm method was not called
+            mock_bucket.objects.filter.return_value.delete.assert_not_called()

--- a/buildstockbatch/test/test_validation.py
+++ b/buildstockbatch/test/test_validation.py
@@ -367,17 +367,29 @@ def test_logic_validation_pass(project_file):
 
 
 @resstock_required
-def test_number_of_options_apply_upgrade():
-    proj_filename = resstock_directory / "project_national" / "sdr_upgrades_tmy3.yml"
+@pytest.mark.parametrize(
+    "opt_count,cost_count,should_raise",
+    [
+        (100, 100, True),
+        (100, 1, True),
+        (1, 100, True),
+        (1, 1, False),
+    ],
+)
+def test_number_of_options_apply_upgrade(opt_count, cost_count, should_raise):
+    proj_filename = os.path.join(example_yml_dir, "complete-schema.yml")
     cfg = get_project_configuration(str(proj_filename))
-    cfg["upgrades"][-1]["options"] = cfg["upgrades"][-1]["options"] * 10
-    cfg["upgrades"][0]["options"][0]["costs"] = cfg["upgrades"][0]["options"][0]["costs"] * 5
+    cfg["upgrades"][-1]["options"] = cfg["upgrades"][-1]["options"] * opt_count
+    cfg["upgrades"][0]["options"][0]["costs"] = cfg["upgrades"][0]["options"][0]["costs"] * cost_count
     with tempfile.TemporaryDirectory() as tmpdir:
         tmppath = pathlib.Path(tmpdir)
         new_proj_filename = tmppath / "project.yml"
         with open(new_proj_filename, "w") as f:
             json.dump(cfg, f)
-        with pytest.raises(ValidationError):
+        if should_raise:
+            with pytest.raises(ValidationError):
+                LocalBatch.validate_number_of_options(str(new_proj_filename))
+        else:
             LocalBatch.validate_number_of_options(str(new_proj_filename))
 
 

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -56,3 +56,10 @@ Development Changelog
 
         Added eplusout_err column in the results_csv to provide visibility into Energplus warnings and errors. Especially useful
         for failed simulations.
+
+    .. change::
+        :tags: postprocessing, feature
+        :pullreq: 500
+
+        Added support for replacing existing results in s3 for buildstock_local. When --replace_existing is passed to buildstock_local,
+        it will replace existing results in s3.


### PR DESCRIPTION
Used in https://github.com/NREL/resstock/pull/1439.

## Pull Request Description

Allows easy replacing of existing result in s3/Athena. Handy for CI to keep a s3 folder / Athena table up to date with latest result. 

## Checklist

Not all may apply

- [x] Code changes (must work)
- [x] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [x] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/coverage.yml` as necessary.
- [x] All other unit and integration tests passing
- [ ] Update validation for project config yaml file changes
- [ ] Update existing documentation
- [ ] Run a small batch run on Kestrel to make sure it all works if you made changes that will affect Kestrel
- [x] Add to the changelog_dev.rst file and propose migration text in the pull request
