### PR TITLE
delete eplusout_err to prevent pyarrow overflow

### DIFF
--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -35,7 +35,7 @@ from buildstockbatch.utils import get_annual_publishing_functions
 import polars as pl
 
 logger = logging.getLogger(__name__)
-print("BSB Patch Aug 2025")
+print("BSB Final Patch Aug 2025")
 
 MAX_PARQUET_MEMORY = 1000  # maximum size (MB) of the parquet file in memory when combining multiple parquets
 
@@ -235,10 +235,11 @@ def read_results_json(fs, filename, all_cols=None):
     with fs.open(filename, "rb") as f1:
         with gzip.open(f1, "rt", encoding="utf-8") as f2:
             dpouts = json.load(f2)
-    if "eplusout_err" in dpouts:  # temporary fix because of too many errors overflowing pyarrow
-        del dpouts["eplusout_err"]
-    if "step_failures" in dpouts:  # temporary fix because of too many errors overflowing pyarrow
-        del dpouts["step_failures"]
+    for dpout in dpouts:
+        if "eplusout_err" in dpout:  # temporary fix because of too many errors overflowing pyarrow
+            del dpout["eplusout_err"]
+        if "step_failures" in dpout:  # temporary fix because of too many errors overflowing pyarrow
+            del dpout["step_failures"]
     df = pd.DataFrame(dpouts)
     df["job_id"] = int(re.search(r"results_job(\d+)\.json\.gz", filename).group(1))
     if all_cols is not None:

--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -234,6 +234,8 @@ def read_results_json(fs, filename, all_cols=None):
     with fs.open(filename, "rb") as f1:
         with gzip.open(f1, "rt", encoding="utf-8") as f2:
             dpouts = json.load(f2)
+    if "eplusout_err" in dpouts:  # temporary fix because of too many errors overflowing pyarrow
+        del dpouts["eplusout_err"]
     df = pd.DataFrame(dpouts)
     df["job_id"] = int(re.search(r"results_job(\d+)\.json\.gz", filename).group(1))
     if all_cols is not None:

--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -236,6 +236,8 @@ def read_results_json(fs, filename, all_cols=None):
             dpouts = json.load(f2)
     if "eplusout_err" in dpouts:  # temporary fix because of too many errors overflowing pyarrow
         del dpouts["eplusout_err"]
+    if "step_failures" in dpouts:  # temporary fix because of too many errors overflowing pyarrow
+        del dpouts["step_failures"]
     df = pd.DataFrame(dpouts)
     df["job_id"] = int(re.search(r"results_job(\d+)\.json\.gz", filename).group(1))
     if all_cols is not None:

--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -35,6 +35,7 @@ from buildstockbatch.utils import get_annual_publishing_functions
 import polars as pl
 
 logger = logging.getLogger(__name__)
+print("BSB Patch Aug 2025")
 
 MAX_PARQUET_MEMORY = 1000  # maximum size (MB) of the parquet file in memory when combining multiple parquets
 


### PR DESCRIPTION
Fixes # .

## Pull Request Description
Trying to fix postprocessing issue in GHPs run. 
My current hypothesis is that because of too many E+ failures in a run, the dataframe's eplusout_err column has run out of space. This is a temporary fix.

<img width="1830" height="834" alt="image" src="https://github.com/user-attachments/assets/cfa8094e-454b-4f5d-8c89-842a6c6224e4" />
Example error from @yingli-NREL 

## Checklist

Not all may apply

- [ ] Code changes (must work)
- [ ] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [ ] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/coverage.yml` as necessary.
- [ ] All other unit and integration tests passing
- [ ] Update validation for project config yaml file changes
- [ ] Update existing documentation
- [ ] Run a small batch run on Kestrel to make sure it all works if you made changes that will affect Kestrel
- [ ] Add to the changelog_dev.rst file and propose migration text in the pull request
