### PR TITLE
Fix timeseries performance warning related to df[col] = np.nan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ jobs:
           repository: NREL/resstock
           path: resstock
           ref: develop
+      - name: Remove AWS from resstock yaml
+        run: |
+          cd resstock
+          python .github/scripts/remove_aws_from_yaml.py project_national/sdr_upgrades_tmy3.yml
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -270,8 +270,10 @@ def read_enduse_timeseries_parquet(fs, all_cols, src_path, bldg_id):
     with fs.open(src_filename, "rb") as f:
         df = pd.read_parquet(f, engine="pyarrow")
     df["building_id"] = bldg_id
+    nan_cols = {}
     for col in set(all_cols).difference(df.columns.values):
-        df[col] = np.nan
+        nan_cols[col] = np.nan * df["building_id"]
+    df = pd.concat([df, pd.DataFrame(nan_cols)], axis=1)
     df = df[all_cols]
     df.set_index("building_id", inplace=True)
     return df

--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -270,11 +270,7 @@ def read_enduse_timeseries_parquet(fs, all_cols, src_path, bldg_id):
     with fs.open(src_filename, "rb") as f:
         df = pd.read_parquet(f, engine="pyarrow")
     df["building_id"] = bldg_id
-    nan_cols = {}
-    for col in set(all_cols).difference(df.columns.values):
-        nan_cols[col] = np.nan * df["building_id"]
-    df = pd.concat([df, pd.DataFrame(nan_cols)], axis=1)
-    df = df[all_cols]
+    df = df.reindex(columns=all_cols)  # fills missing cols with nan
     df.set_index("building_id", inplace=True)
     return df
 


### PR DESCRIPTION
## Pull Request Description

Seeing this a bunch of times on resstock CI in the `integration-tests` job:
```
/home/runner/work/resstock/buildstockbatch/buildstockbatch/postprocessing.py:274: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`
  df[col] = np.nan
```

This PR appears to make the above warning go away.

For example before and after, see the "Run simulations" step in:
* Before: https://github.com/NREL/resstock/actions/runs/16679658214/job/47216466376
* After: https://github.com/NREL/resstock/actions/runs/16681544951/job/47221842682

## Checklist

Not all may apply

- [ ] Code changes (must work)
- [ ] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [ ] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/coverage.yml` as necessary.
- [ ] All other unit and integration tests passing
- [ ] Update validation for project config yaml file changes
- [ ] Update existing documentation
- [ ] Run a small batch run on Kestrel to make sure it all works if you made changes that will affect Kestrel
- [ ] Add to the changelog_dev.rst file and propose migration text in the pull request
