### PR TITLE
Fix pandas 3.x compatibility: cast building ID index to int after CSV read

### DIFF
--- a/buildstockbatch/cloud/docker_base.py
+++ b/buildstockbatch/cloud/docker_base.py
@@ -431,6 +431,7 @@ class DockerBatchBase(BuildStockBatchBase):
 
         logger.debug("Validating sampled buildstock...")
         df = read_csv(buildstock_csv_filename, index_col=0, dtype=str)
+        df.index = df.index.astype(int)
         self.validate_buildstock_csv(self.project_filename, df)
         building_ids = df.index.tolist()
         n_datapoints = len(building_ids)

--- a/buildstockbatch/hpc.py
+++ b/buildstockbatch/hpc.py
@@ -155,6 +155,7 @@ class SlurmBatch(BuildStockBatchBase):
 
         # Determine the number of simulations expected to be executed
         df = read_csv(buildstock_csv_filename, index_col=0, dtype=str)
+        df.index = df.index.astype(int)
         self.validate_buildstock_csv(self.project_filename, df)
 
         # find out how many buildings there are to simulate

--- a/buildstockbatch/local.py
+++ b/buildstockbatch/local.py
@@ -242,6 +242,7 @@ class LocalBatch(BuildStockBatchBase):
         )
 
         df = read_csv(buildstock_csv_filename, index_col=0, dtype=str)
+        df.index = df.index.astype(int)
         self.validate_buildstock_csv(self.project_filename, df)
 
         building_ids = df.index.tolist()

--- a/buildstockbatch/sampler/downselect.py
+++ b/buildstockbatch/sampler/downselect.py
@@ -104,6 +104,7 @@ class DownselectSamplerBase(BuildStockSampler):
             init_sampler = self.SUB_SAMPLER_CLASS(self.parent(), n_datapoints=n_samples_init, **self.sub_kw)
             buildstock_csv_filename = init_sampler.run_sampling()
             df = read_csv(buildstock_csv_filename, index_col=0, dtype=str)
+            df.index = df.index.astype(int)
             df_new = df[self.downselect_logic(df, self.logic)]
             downselected_n_samples_init = df_new.shape[0]
             n_samples = math.ceil(self.n_datapoints * n_samples_init / downselected_n_samples_init)
@@ -117,6 +118,7 @@ class DownselectSamplerBase(BuildStockSampler):
             with open(buildstock_csv_filename, "rb") as f_in:
                 shutil.copyfileobj(f_in, f_out)
         df = read_csv(buildstock_csv_filename, index_col=0, dtype="str")
+        df.index = df.index.astype(int)
         df_new = df[self.downselect_logic(df, self.logic)]
         if len(df_new.index) == 0:
             raise RuntimeError("There are no buildings left after the down select!")


### PR DESCRIPTION
Fixes # 521

## Pull Request Description

In pandas 3.x, `dtype=str` in `read_csv()` now strictly applies to the index when `index_col=0` is used, causing building IDs to be returned as strings instead of integers. This breaks the format string `"bldg{:07d}up{:02d}".format(building_id, ...)` in `base.py` with a `ValueError: Unknown format code 'd' for object of type 'str'`.

This fix explicitly casts the DataFrame index back to `int` immediately after reading the buildstock CSV in all three execution paths (local, HPC, and cloud/Docker) as well as in sampler/downselect.py. The fix is backward-compatible with pandas 2.x, where `.astype(int)` is harmless since the index was already integer.

Two previously failing tests (test_resstock_local_batch[national_baseline] and test_resstock_local_batch[testing_baseline]) now pass with this fix.

**Files changed:**
- `buildstockbatch/local.py`
- `buildstockbatch/hpc.py`
- `buildstockbatch/cloud/docker_base.py`
- `buildstockbatch/sampler/downselect.py`

## Checklist

Not all may apply

- [x] Code changes (must work)
- [ ] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [ ] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/coverage.yml` as necessary.
- [ ] All other unit and integration tests passing
- [ ] Update validation for project config yaml file changes
- [ ] Update existing documentation
- [ ] Run a small batch run on Kestrel to make sure it all works if you made changes that will affect Kestrel
- [ ] Add to the changelog_dev.rst file and propose migration text in the pull request
