### PR TITLE
Fix pandas 3.x compatibility and most CI failures

### DIFF
--- a/.github/workflows/add_to_project.yml
+++ b/.github/workflows/add_to_project.yml
@@ -19,7 +19,7 @@ jobs:
     name: Add pull request or issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.3.0
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/NatLabRockies/projects/38
           github-token: ${{ secrets.GHB_TOKEN }}

--- a/.github/workflows/add_to_project.yml
+++ b/.github/workflows/add_to_project.yml
@@ -21,5 +21,5 @@ jobs:
     steps:
       - uses: actions/add-to-project@v0.3.0
         with:
-          project-url: https://github.com/orgs/NREL/projects/38
+          project-url: https://github.com/orgs/NatLabRockies/projects/38
           github-token: ${{ secrets.GHB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           repository: NREL/resstock
           path: resstock
-          ref: develop
+          ref: fix_apply_measure
       - name: Remove AWS from resstock yaml
         run: |
           cd resstock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           repository: NREL/resstock
           path: resstock
-          ref: fix_apply_measure
+          ref: develop
       - name: Remove AWS from resstock yaml
         run: |
           cd resstock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
         python-version: ['3.12']
     name: Tests - Python ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: buildstockbatch
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: NREL/resstock
           path: resstock
@@ -33,7 +33,7 @@ jobs:
         run: |
           cd resstock
           python .github/scripts/remove_aws_from_yaml.py project_national/sdr_upgrades_amy2018.yml
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Download weather
@@ -67,31 +67,31 @@ jobs:
           pytest -vv --junitxml=coverage/junit.xml --cov=buildstockbatch --cov-report=xml:coverage/coverage.xml --cov-report=html:coverage/htmlreport
       - name: Test Report
         uses: mikepenz/action-junit-report@v3.5.2
-        if: ${{ matrix.python-version == '3.11' }}
+        if: ${{ matrix.python-version == '3.12' }}
         with:
           report_paths: buildstockbatch/coverage/junit.xml
           check_name: Testing Report
           fail_on_failure: true
       - name: Save Coverage Report
-        uses: actions/upload-artifact@v4
-        if: ${{ matrix.python-version == '3.11' }}
+        uses: actions/upload-artifact@v7
+        if: ${{ matrix.python-version == '3.12' }}
         with:
           name: coverage-report-html
           path: buildstockbatch/coverage/htmlreport/
       - name: Save Coverage Report XML
-        uses: actions/upload-artifact@v4
-        if: ${{ matrix.python-version == '3.11' }}
+        uses: actions/upload-artifact@v7
+        if: ${{ matrix.python-version == '3.12' }}
         with:
           name: coverage-report-xml
           path: buildstockbatch/coverage/coverage.xml
       - name: Build documentation
-        if: ${{ matrix.python-version == '3.11' }}
+        if: ${{ matrix.python-version == '3.12' }}
         run: |
           cd buildstockbatch/docs
           make html SPHINXOPTS="-W --keep-going -n"
       - name: Save Docs
-        uses: actions/upload-artifact@v4
-        if: ${{ matrix.python-version == '3.11' }}
+        uses: actions/upload-artifact@v7
+        if: ${{ matrix.python-version == '3.12' }}
         with:
           name: documentation
           path: buildstockbatch/docs/_build/html/
@@ -100,12 +100,12 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: NREL/resstock
           path: resstock
           ref: develop
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.12
       - name: Download weather

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,7 @@ jobs:
       }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_commit.id }}
@@ -38,7 +38,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -57,7 +57,7 @@ jobs:
           thresholds: '33 75'
 
       - name: Comment on the PR
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           recreate: true
           number: ${{ github.event.workflow_run.pull_requests[0].number }}

--- a/buildstockbatch/__version__.py
+++ b/buildstockbatch/__version__.py
@@ -1,6 +1,5 @@
 import datetime as dt
 
-
 __title__ = "buildstockbatch"
 __description__ = "Executing BuildStock projects on batch infrastructure."
 __url__ = "http://github.com/NREL/buildstockbatch"

--- a/buildstockbatch/aws/aws.py
+++ b/buildstockbatch/aws/aws.py
@@ -9,6 +9,7 @@ This class contains the object & methods that allow for usage of the library wit
 :copyright: (c) 2018 by The Alliance for Sustainable Energy
 :license: BSD-3
 """
+
 import argparse
 import base64
 import boto3

--- a/buildstockbatch/aws/awsbase.py
+++ b/buildstockbatch/aws/awsbase.py
@@ -1,7 +1,6 @@
 import logging
 from botocore.config import Config
 
-
 logger = logging.getLogger(__name__)
 
 boto_client_config = Config(retries={"max_attempts": 5, "mode": "standard"})

--- a/buildstockbatch/cloud/docker_base.py
+++ b/buildstockbatch/cloud/docker_base.py
@@ -8,6 +8,7 @@ This is the base class mixed into classes that deploy using a docker container.
 :author: Natalie Weires
 :license: BSD-3
 """
+
 import collections
 import csv
 from dataclasses import dataclass

--- a/buildstockbatch/cloud/docker_base.py
+++ b/buildstockbatch/cloud/docker_base.py
@@ -431,6 +431,7 @@ class DockerBatchBase(BuildStockBatchBase):
 
         logger.debug("Validating sampled buildstock...")
         df = read_csv(buildstock_csv_filename, index_col=0, dtype=str)
+        df.index = df.index.astype(int)
         self.validate_buildstock_csv(self.project_filename, df)
         building_ids = df.index.tolist()
         n_datapoints = len(building_ids)

--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -11,6 +11,7 @@ See the README for an overview of the architecture.
 :copyright: (c) 2023 by The Alliance for Sustainable Energy
 :license: BSD-3
 """
+
 import argparse
 import collections
 from dask.distributed import Client as DaskClient
@@ -44,7 +45,6 @@ from buildstockbatch.utils import (
     get_project_configuration,
     log_error_details,
 )
-
 
 logger = logging.getLogger(__name__)
 
@@ -659,8 +659,7 @@ class GcpBatch(DockerBatchBase):
             f"{self.region}/jobs/{self.job_identifier}/details?project={self.gcp_project}"
         )
 
-        logger.info(
-            f"""
+        logger.info(f"""
 ╔══════════════════════════════════════════════════════════════════════════════╗
 ║ GCP Batch Job for running simulations has started!                           ║
 ║                                                                              ║
@@ -676,8 +675,7 @@ Job UID:
     {job_url}
 Results output browser (Cloud Console):
     https://console.cloud.google.com/storage/browser/{self.gcs_bucket}/{self.gcs_prefix}/results/simulation_output
-"""
-        )
+""")
 
         # Monitor job status while waiting for the job to complete
         n_completed_last_time = 0
@@ -910,8 +908,7 @@ Results output browser (Cloud Console):
         try:
             op = jobs_client.run_job(name=self.postprocessing_job_name)
 
-            logger.info(
-                f"""
+            logger.info(f"""
 ╔══════════════════════════════════════════════════════════════════════════════╗
 ║ Post-processing Cloud Run Job started!                                       ║
 ║                                                                              ║
@@ -923,8 +920,7 @@ Results output browser (Cloud Console):
 Results output browser (Cloud Console):
     https://console.cloud.google.com/storage/browser/{self.gcs_bucket}/{self.gcs_prefix}/results/
 
-Run this script with --clean to clean up the GCP environment after post-processing is complete."""
-            )
+Run this script with --clean to clean up the GCP environment after post-processing is complete.""")
         except:
             logger.warning(
                 "Post-processing Cloud Run job failed to start. "

--- a/buildstockbatch/hpc.py
+++ b/buildstockbatch/hpc.py
@@ -155,6 +155,7 @@ class SlurmBatch(BuildStockBatchBase):
 
         # Determine the number of simulations expected to be executed
         df = read_csv(buildstock_csv_filename, index_col=0, dtype=str)
+        df.index = df.index.astype(int)
         self.validate_buildstock_csv(self.project_filename, df)
 
         # find out how many buildings there are to simulate

--- a/buildstockbatch/local.py
+++ b/buildstockbatch/local.py
@@ -242,6 +242,7 @@ class LocalBatch(BuildStockBatchBase):
         )
 
         df = read_csv(buildstock_csv_filename, index_col=0, dtype=str)
+        df.index = df.index.astype(int)
         self.validate_buildstock_csv(self.project_filename, df)
 
         building_ids = df.index.tolist()

--- a/buildstockbatch/postprocessing.py
+++ b/buildstockbatch/postprocessing.py
@@ -9,6 +9,7 @@ A module containing utility functions for postprocessing
 :copyright: (c) 2018 by The Alliance for Sustainable Energy
 :license: BSD-3
 """
+
 import boto3
 import botocore.exceptions
 import dask.bag as db

--- a/buildstockbatch/sampler/downselect.py
+++ b/buildstockbatch/sampler/downselect.py
@@ -104,6 +104,7 @@ class DownselectSamplerBase(BuildStockSampler):
             init_sampler = self.SUB_SAMPLER_CLASS(self.parent(), n_datapoints=n_samples_init, **self.sub_kw)
             buildstock_csv_filename = init_sampler.run_sampling()
             df = read_csv(buildstock_csv_filename, index_col=0, dtype=str)
+            df.index = df.index.astype(int)
             df_new = df[self.downselect_logic(df, self.logic)]
             downselected_n_samples_init = df_new.shape[0]
             n_samples = math.ceil(self.n_datapoints * n_samples_init / downselected_n_samples_init)
@@ -117,6 +118,7 @@ class DownselectSamplerBase(BuildStockSampler):
             with open(buildstock_csv_filename, "rb") as f_in:
                 shutil.copyfileobj(f_in, f_out)
         df = read_csv(buildstock_csv_filename, index_col=0, dtype="str")
+        df.index = df.index.astype(int)
         df_new = df[self.downselect_logic(df, self.logic)]
         if len(df_new.index) == 0:
             raise RuntimeError("There are no buildings left after the down select!")

--- a/buildstockbatch/test/shared_testing_stuff.py
+++ b/buildstockbatch/test/shared_testing_stuff.py
@@ -4,7 +4,6 @@ import os
 import pathlib
 import pytest
 
-
 resstock_directory = pathlib.Path(
     os.environ.get(
         "RESSTOCK_DIR",

--- a/buildstockbatch/utils.py
+++ b/buildstockbatch/utils.py
@@ -9,7 +9,6 @@ import shutil
 import traceback
 import yaml
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/buildstockbatch/workflow_generator/base.py
+++ b/buildstockbatch/workflow_generator/base.py
@@ -12,7 +12,6 @@ This object contains the base class for generating OSW files from individual sam
 
 import logging
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -54,7 +54,7 @@ Development Changelog
         :pullreq: 499
 
 
-        Added eplusout_err column in the results_csv to provide visibility into Energplus warnings and errors. Especially useful
+        Added eplusout_err column in the results_csv to provide visibility into EnergyPlus warnings and errors. Especially useful
         for failed simulations.
 
     .. change::
@@ -69,8 +69,8 @@ Development Changelog
         :pullreq: 501
 
         Introduce a bunch of changes originating from issues in SDR run.
-        1. Indermediate files are not cleaned up after postprocessing. This allows for re-running postprocessing.
-        2. eplusout_err and step_failures are truncted to 100000 chars. eplusout_err is only collected if E+ terminated.
+        1. Intermediate files are not cleaned up after postprocessing. This allows for re-running postprocessing.
+        2. eplusout_err and step_failures are truncated to 100000 chars. eplusout_err is only collected if E+ terminated.
         3. Default for include_annual_emission_end_uses is changed to False.
         4. Default for timeseries_num_decimal_places is changed to 5.
         5. When SimulationOutputReport or ReportSimulationOutput is both missing in data_point_out.json (perhaps due to failure),

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ from codecs import open
 import os
 import setuptools
 
-
 here = os.path.abspath(os.path.dirname(__file__))
 metadata = {}
 


### PR DESCRIPTION
Fixes #521.

## Pull Request Description

Copy of #522 that runs CI.

Also fixes some CI steps that were not running because they depended on python 3.11 but we were running 3.12 (this broke [here](https://github.com/NatLabRockies/buildstockbatch/pull/518) where 3.11 was removed from the test matrix).

After this PR, all tests now pass except for one failure due to changes to resstockpostproc (that is being worked on [here](https://github.com/NatLabRockies/buildstockbatch/pull/520)).

## Checklist

Not all may apply

- [ ] Code changes (must work)
- [ ] Tests exercising your feature/bug fix (check coverage report on Checks -> BuildStockBatch Tests -> Artifacts)
- [ ] Coverage has increased or at least not decreased. Update `minimum_coverage` in `.github/workflows/coverage.yml` as necessary.
- [ ] All other unit and integration tests passing
- [ ] Update validation for project config yaml file changes
- [ ] Update existing documentation
- [ ] Run a small batch run on Kestrel to make sure it all works if you made changes that will affect Kestrel
- [ ] Add to the changelog_dev.rst file and propose migration text in the pull request
