### PR TITLE
Run ComStock (and other custom-image projects) on AWS; cloud postprocessing; AWS reliability fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,6 @@ RUN uv venv --python 3.11 "$VIRTUAL_ENV" && uv pip install "/buildstock-batch[${
 # venv goes last on PATH: dask/buildstockbatch executables resolve when the base
 # image doesn't provide them, without shadowing base-image interpreters and tools.
 ENV PATH="$PATH:$VIRTUAL_ENV/bin"
-# dask_cloudprovider starts scheduler/worker containers with the legacy
-# "dask-scheduler"/"dask-worker" commands, which modern distributed no longer installs.
-RUN printf '#!/bin/sh\nexec /buildstock-batch/.venv/bin/dask scheduler "$@"\n' > /usr/local/bin/dask-scheduler \
-    && printf '#!/bin/sh\nexec /buildstock-batch/.venv/bin/dask worker "$@"\n' > /usr/local/bin/dask-worker \
-    && chmod +x /usr/local/bin/dask-scheduler /usr/local/bin/dask-worker
 
 # Base plus custom gems
 FROM --platform=linux/amd64 buildstockbatch as buildstockbatch-custom-gems

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 ARG OS_VER
-FROM --platform=linux/amd64 nrel/openstudio:$OS_VER as buildstockbatch
+# BASE_IMAGE may be overridden (e.g. with a locally built ComStock image) to run simulations
+# in a project-provided environment. It must contain OpenStudio matching OS_VER, plus curl
+# and ca-certificates.
+ARG BASE_IMAGE=nrel/openstudio:$OS_VER
+FROM --platform=linux/amd64 $BASE_IMAGE as buildstockbatch
 ARG CLOUD_PLATFORM=aws
 ENV DEBIAN_FRONTEND=noninteractive
 COPY . /buildstock-batch/
@@ -8,8 +12,21 @@ RUN update-ca-certificates
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH="/root/.local/bin:/root/.cargo/bin:$PATH"
-RUN uv python install 3.11
-RUN uv venv --python 3.11 && uv pip install "/buildstock-batch[${CLOUD_PLATFORM}]"
+# --no-bin: don't put a bare python3.11 shim on PATH, where it would shadow a
+# python3.11 provided by the base image (e.g. ComStock's, which has PySAM et al.)
+RUN uv python install 3.11 --no-bin
+# The venv must live outside /var/simdata/openstudio: the base image declares that
+# path as a VOLUME, so anything written there during the build is discarded.
+ENV VIRTUAL_ENV=/buildstock-batch/.venv
+RUN uv venv --python 3.11 "$VIRTUAL_ENV" && uv pip install "/buildstock-batch[${CLOUD_PLATFORM}]"
+# venv goes last on PATH: dask/buildstockbatch executables resolve when the base
+# image doesn't provide them, without shadowing base-image interpreters and tools.
+ENV PATH="$PATH:$VIRTUAL_ENV/bin"
+# dask_cloudprovider starts scheduler/worker containers with the legacy
+# "dask-scheduler"/"dask-worker" commands, which modern distributed no longer installs.
+RUN printf '#!/bin/sh\nexec /buildstock-batch/.venv/bin/dask scheduler "$@"\n' > /usr/local/bin/dask-scheduler \
+    && printf '#!/bin/sh\nexec /buildstock-batch/.venv/bin/dask worker "$@"\n' > /usr/local/bin/dask-worker \
+    && chmod +x /usr/local/bin/dask-scheduler /usr/local/bin/dask-worker
 
 # Base plus custom gems
 FROM --platform=linux/amd64 buildstockbatch as buildstockbatch-custom-gems

--- a/buildstockbatch/aws/aws.py
+++ b/buildstockbatch/aws/aws.py
@@ -13,12 +13,9 @@ This class contains the object & methods that allow for usage of the library wit
 import argparse
 import base64
 import boto3
-import docker
 from botocore.exceptions import ClientError
-from copy import deepcopy
 import csv
 from dask.distributed import Client, LocalCluster
-from dask_cloudprovider.aws import FargateCluster
 import gzip
 from joblib import Parallel, delayed
 import json
@@ -30,20 +27,15 @@ from s3fs import S3FileSystem
 import shutil
 import tarfile
 import re
-import tempfile
 import time
 import tqdm
 import io
-import yaml
 
+from buildstockbatch import postprocessing
 from buildstockbatch.aws.awsbase import AwsJobBase, boto_client_config
-from buildstockbatch.base import ValidationError
 from buildstockbatch.cloud import docker_base
 from buildstockbatch.utils import (
     log_error_details,
-    get_project_configuration,
-    get_bool_env_var,
-    path_rel_to_file,
 )
 
 logger = logging.getLogger(__name__)
@@ -720,7 +712,7 @@ class AwsBatchEnv(AwsJobBase):
         else:
             raise RuntimeError(f"Job queue {self.batch_job_queue_name} did not reach the VALID state")
 
-    def create_job_definition(self, docker_image, vcpus, memory, command, env_vars):
+    def create_job_definition(self, docker_image, vcpus, memory, command, env_vars, job_def_name=None):
         """
         Creates a job definition to run in the Batch environment.  This will create a new version with every execution.
         :param docker_image: The image ID from the related ECR enviornment
@@ -728,9 +720,11 @@ class AwsBatchEnv(AwsJobBase):
         :param memory: Numeric value of the memory MBs dedicated to each container
         :param command: Command to run in the container
         :param env_vars: Dictionary of key/value environment variables to include in the job
+        :param job_def_name: Name of the job definition; defaults to the job identifier
+        :returns: The ARN of the created job definition
         """
         response = self.batch.register_job_definition(
-            jobDefinitionName=self.job_identifier,
+            jobDefinitionName=job_def_name or self.job_identifier,
             type="container",
             # parameters={
             #    'string': 'string'
@@ -748,7 +742,9 @@ class AwsBatchEnv(AwsJobBase):
             tags=self.get_tags(),
         )
 
-        self.job_definition_arn = response["jobDefinitionArn"]
+        if job_def_name is None:
+            self.job_definition_arn = response["jobDefinitionArn"]
+        return response["jobDefinitionArn"]
 
     def submit_job(self, array_size=4):
         """
@@ -765,6 +761,20 @@ class AwsBatchEnv(AwsJobBase):
         )
 
         logger.info(f"Job {self.job_identifier} submitted.")
+        return resp
+
+    def submit_postprocessing_job(self, job_definition_arn):
+        """
+        Submits a single (non-array) job that runs postprocessing in the cloud.
+        """
+        resp = backoff(
+            self.batch.submit_job,
+            jobName=f"{self.job_identifier}-postprocessing",
+            jobQueue=self.batch_job_queue_name,
+            jobDefinition=job_definition_arn,
+            tags=self.get_tags(),
+        )
+        logger.info(f"Postprocessing job {self.job_identifier}-postprocessing submitted.")
         return resp
 
     def clean(self):
@@ -993,16 +1003,11 @@ class AwsBatchEnv(AwsJobBase):
 
             response = self.ec2.release_address(AllocationId=this_address)
 
-        try:
-            self.ec2.delete_security_group(GroupName=f"dask-{self.job_identifier}")
-        except ClientError as error:
-            if error.response["Error"]["Code"] == "InvalidGroup.NotFound":
-                pass
-            else:
-                raise error
-
 
 class AwsBatch(docker_base.DockerBatchBase):
+    DEFAULT_PP_VCPUS = 4
+    DEFAULT_PP_MEMORY_MIB = 30720
+
     def __init__(self, project_filename):
         super().__init__(project_filename)
 
@@ -1019,40 +1024,8 @@ class AwsBatch(docker_base.DockerBatchBase):
         self.boto3_session = boto3.Session(region_name=self.region)
 
     @staticmethod
-    def validate_dask_settings(project_file):
-        cfg = get_project_configuration(project_file)
-        if "emr" in cfg["aws"]:
-            logger.warning("The `aws.emr` configuration is no longer used and is ignored. Recommend removing.")
-        dask_cfg = cfg["aws"]["dask"]
-        errors = []
-        mem_rules = {
-            1024: (2, 8, 1),
-            2048: (4, 16, 1),
-            4096: (8, 30, 1),
-            8192: (16, 60, 4),
-            16384: (32, 120, 8),
-        }
-        for node_type in ("scheduler", "worker"):
-            mem = dask_cfg.get(f"{node_type}_memory", 8 * 1024)
-            if mem % 1024 != 0:
-                errors.append(f"`aws.dask.{node_type}_memory` = {mem}, needs to be a multiple of 1024.")
-            mem_gb = mem // 1024
-            min_gb, max_gb, incr_gb = mem_rules[dask_cfg.get(f"{node_type}_cpu", 2 * 1024)]
-            if not (min_gb <= mem_gb <= max_gb and (mem_gb - min_gb) % incr_gb == 0):
-                errors.append(
-                    f"`aws.dask.{node_type}_memory` = {mem}, "
-                    f"should be between {min_gb * 1024} and {max_gb * 1024} in a multiple of {incr_gb * 1024}."
-                )
-        if errors:
-            errors.append("See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html")
-            raise ValidationError("\n".join(errors))
-
-        return True
-
-    @staticmethod
     def validate_project(project_file):
         super(AwsBatch, AwsBatch).validate_project(project_file)
-        AwsBatch.validate_dask_settings(project_file)
         AwsBatch.validate_base_dockerfile(project_file, "aws")
 
     @property
@@ -1275,123 +1248,122 @@ class AwsBatch(docker_base.DockerBatchBase):
     def get_fs(self):
         return S3FileSystem()
 
-    def get_dask_client(self):
-        dask_cfg = self.cfg["aws"]["dask"]
-
-        if not dask_cfg.get("use_fargate_cluster", True):
-            # Run dask locally (inside the postprocessing container). Useful when the
-            # Fargate scheduler isn't reachable from the machine running postprocessing,
-            # e.g. from behind a corporate network that blocks the dask protocol.
-            logger.info("Using a local dask cluster for postprocessing")
-            self.dask_cluster = LocalCluster(n_workers=dask_cfg.get("n_workers", 2))
-            self.dask_client = Client(self.dask_cluster)
-            return self.dask_client
-
-        batch_env = AwsBatchEnv(self.job_identifier, self.cfg["aws"], self.boto3_session)
-        m = 1024
-        fargate_vpc_kwargs = {}
-        existing_vpc = self.cfg["aws"].get("vpc")
-        if existing_vpc:
-            fargate_vpc_kwargs["vpc"] = existing_vpc["vpc_id"]
-            # The dask scheduler must be reachable from the machine running postprocessing,
-            # so its subnets (public, internet-gateway-routed) may differ from the Batch ones.
-            fargate_vpc_kwargs["subnets"] = existing_vpc.get("dask_subnet_ids", existing_vpc["subnet_ids"])
-            if existing_vpc.get("security_group_id"):
-                fargate_vpc_kwargs["security_groups"] = [existing_vpc["security_group_id"]]
-            # dask_cloudprovider's stale-resource sweep deletes security groups by name,
-            # which only works in the default VPC; it crashes on groups in other VPCs.
-            fargate_vpc_kwargs["skip_cleanup"] = True
-        self.dask_cluster = FargateCluster(
-            region_name=self.region,
-            fargate_spot=True,
-            image=self.image_url,
-            cluster_name_template=f"dask-{self.job_identifier}",
-            scheduler_cpu=dask_cfg.get("scheduler_cpu", 2 * m),
-            scheduler_mem=dask_cfg.get("scheduler_memory", 8 * m),
-            worker_cpu=dask_cfg.get("worker_cpu", 2 * m),
-            worker_mem=dask_cfg.get("worker_memory", 8 * m),
-            n_workers=dask_cfg["n_workers"],
-            task_role_policies=["arn:aws:iam::aws:policy/AmazonS3FullAccess"],
-            tags=batch_env.get_tags(),
-            **fargate_vpc_kwargs,
-        )
-        self.dask_client = Client(self.dask_cluster)
-        return self.dask_client
-
-    def cleanup_dask(self):
-        self.dask_client.close()
-        self.dask_cluster.close()
-
     def upload_results(self, *args, **kwargs):
         """Do nothing because the results are already on S3"""
         return self.s3_bucket, self.s3_bucket_prefix + "/results/parquet"
 
-    def process_results(self, *args, **kwargs):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            tmppath = pathlib.Path(tmpdir)
-            container_workpath = pathlib.PurePosixPath("/var/simdata/openstudio")
+    def process_results(self, skip_combine=False, use_dask_cluster=True):
+        """
+        Overrides `BuildStockBatchBase.process_results()`.
 
-            cfg = deepcopy(self.cfg)
-            container_buildstock_dir = str(container_workpath / "buildstock")
-            cfg["buildstock_directory"] = container_buildstock_dir
-            cfg["project_directory"] = str(pathlib.Path(self.project_dir).relative_to(self.buildstock_dir))
+        Instead of running `combine_results` on the machine that submitted the batch, this
+        submits an AWS Batch job that runs it in the cloud (the same approach GCP uses with
+        a Cloud Run job). The job reads from and writes to S3 directly, so nothing needs to
+        be transferred to or from this machine, and no connection back to it is required.
 
-            # Make a precomputed sample file available inside the container, where it is
-            # re-validated relative to the project config file's location.
-            sampler_args = cfg.get("sampler", {}).get("args", {})
-            if "sample_file" in sampler_args:
-                sample_file = path_rel_to_file(self.project_filename, sampler_args["sample_file"])
-                shutil.copy(sample_file, tmppath / "buildstock.csv")
-                sampler_args["sample_file"] = "buildstock.csv"
+        The Athena table creation step (if configured), which only makes AWS API calls,
+        still runs from this machine via the parent implementation.
+        """
+        if not skip_combine:
+            self.start_combine_results_job_on_cloud()
+        super().process_results(skip_combine=True, use_dask_cluster=False)
 
-            with open(tmppath / "project_config.yml", "w") as f:
-                f.write(yaml.dump(cfg, Dumper=yaml.SafeDumper))
-            container_cfg_path = str(container_workpath / "project_config.yml")
+    def start_combine_results_job_on_cloud(self):
+        """Submit an AWS Batch job that runs `combine_results` in the cloud and wait for it."""
+        do_timeseries = False
+        wfg_args = self.cfg["workflow_generator"].get("args", {})
+        if self.cfg["workflow_generator"]["type"] == "residential_hpxml":
+            if "simulation_output_report" in wfg_args.keys():
+                if "timeseries_frequency" in wfg_args["simulation_output_report"].keys():
+                    do_timeseries = wfg_args["simulation_output_report"]["timeseries_frequency"] != "none"
+        else:
+            do_timeseries = "timeseries_csv_export" in wfg_args.keys()
 
-            with open(tmppath / "args.json", "w") as f:
-                json.dump([args, kwargs], f)
+        # Ensure the Batch environment exists. These are all no-ops right after a
+        # simulation run, but --postprocessonly may need to (re)create it.
+        batch_env = AwsBatchEnv(self.job_identifier, self.cfg["aws"], self.boto3_session)
+        batch_env.create_batch_service_roles()
+        batch_env.create_vpc()
+        batch_env.create_compute_environment()
+        batch_env.create_job_queue()
 
-            credentials = boto3.Session().get_credentials().get_frozen_credentials()
-            env = {
-                "AWS_ACCESS_KEY_ID": credentials.access_key,
-                "AWS_SECRET_ACCESS_KEY": credentials.secret_key,
-            }
-            if credentials.token:
-                env["AWS_SESSION_TOKEN"] = credentials.token
-            env["POSTPROCESSING_INSIDE_DOCKER_CONTAINER"] = "true"
+        pp_env_cfg = self.cfg["aws"].get("postprocessing_environment", {})
+        n_vcpus = pp_env_cfg.get("vcpus", self.DEFAULT_PP_VCPUS)
+        memory_mib = pp_env_cfg.get("memory", self.DEFAULT_PP_MEMORY_MIB)
 
-            logger.info("Starting container for postprocessing")
-            # Remove a leftover container from a previous interrupted run
-            try:
-                self.docker_client.containers.get("bsb_post").remove(force=True)
-            except docker.errors.NotFound:
-                pass
-            container = self.docker_client.containers.run(
-                self.image_url,
-                [docker_base.CONTAINER_BUILDSTOCKBATCH_PYTHON, "-m", "buildstockbatch.aws.aws", container_cfg_path],
-                volumes={
-                    tmpdir: {"bind": str(container_workpath), "mode": "rw"},
-                    self.buildstock_dir: {"bind": container_buildstock_dir, "mode": "ro"},
-                },
-                environment=env,
-                name="bsb_post",
-                detach=True,
+        env_vars = {
+            "JOB_TYPE": "POSTPROCESS",
+            "S3_BUCKET": self.s3_bucket,
+            "S3_PREFIX": self.s3_bucket_prefix,
+            "DO_TIMESERIES": "True" if do_timeseries else "False",
+            "DASK_N_WORKERS": str(n_vcpus),
+            "DASK_MEMORY_LIMIT_MB": str(memory_mib // n_vcpus),
+        }
+        job_def_arn = batch_env.create_job_definition(
+            self.image_url,
+            command=[docker_base.CONTAINER_BUILDSTOCKBATCH_PYTHON, "-m", "buildstockbatch.aws.aws"],
+            vcpus=n_vcpus,
+            memory=memory_mib,
+            env_vars=env_vars,
+            job_def_name=f"{self.job_identifier}_pp",
+        )
+        job_id = batch_env.submit_postprocessing_job(job_def_arn)["jobId"]
+
+        logger.info("Waiting for the postprocessing job to complete...")
+        logs = self.boto3_session.client("logs", config=boto_client_config)
+        log_stream_name = None
+        next_log_token = None
+        last_status = None
+        while True:
+            time.sleep(10)
+            job_desc = batch_env.batch.describe_jobs(jobs=[job_id])["jobs"][0]
+            job_status = job_desc["status"]
+            if job_status != last_status:
+                logger.info(f"Postprocessing job status: {job_status}")
+                last_status = job_status
+            if log_stream_name is None:
+                log_stream_name = job_desc.get("container", {}).get("logStreamName")
+            if log_stream_name is not None:
+                try:
+                    log_kwargs = {"nextToken": next_log_token} if next_log_token else {"startFromHead": True}
+                    resp = logs.get_log_events(
+                        logGroupName="/aws/batch/job", logStreamName=log_stream_name, **log_kwargs
+                    )
+                    for event in resp["events"]:
+                        logger.debug("[postprocessing] " + event["message"])
+                    next_log_token = resp["nextForwardToken"]
+                except logs.exceptions.ResourceNotFoundException:
+                    pass
+            if job_status in ("SUCCEEDED", "FAILED"):
+                break
+        if job_status == "FAILED":
+            raise RuntimeError(
+                "The postprocessing job failed. See the CloudWatch logs "
+                f"(log group /aws/batch/job, log stream {log_stream_name})."
             )
-            try:
-                for msg in container.logs(stream=True):
-                    logger.debug(msg)
-                result = container.wait()
-            finally:
-                container.remove(force=True)
-            if result.get("StatusCode", 1) != 0:
-                raise RuntimeError(f"Postprocessing failed. The bsb_post container exited with {result}")
 
-    def _process_results_inside_container(self):
-        with open("/var/simdata/openstudio/args.json", "r") as f:
-            args, kwargs = json.load(f)
+    @classmethod
+    def run_combine_results_on_cloud(cls, s3_bucket, s3_prefix, do_timeseries):
+        """Run `combine_results` in the cloud.
 
-        logger.info("Running postprocessing in container")
-        super().process_results(*args, **kwargs)
+        This runs inside the AWS Batch postprocessing job container submitted by
+        `start_combine_results_job_on_cloud`.
+        """
+        logger.info("run_combine_results_on_cloud starting")
+        s3 = boto3.client("s3", config=boto_client_config)
+        with io.BytesIO() as f:
+            s3.download_fileobj(s3_bucket, f"{s3_prefix}/config.json", f)
+            cfg = json.loads(f.getvalue())
+
+        # Size the dask cluster explicitly: from inside the container, dask sees the host
+        # instance's CPUs and memory, not the resources allotted to this Batch job.
+        n_workers = int(os.environ["DASK_N_WORKERS"])
+        memory_limit_mb = int(os.environ["DASK_MEMORY_LIMIT_MB"])
+        cluster = LocalCluster(n_workers=n_workers, threads_per_worker=2, memory_limit=f"{memory_limit_mb}MB")
+        Client(cluster)
+
+        results_dir = f"{s3_bucket}/{s3_prefix}/results"
+        postprocessing.combine_results(S3FileSystem(), results_dir, cfg, do_timeseries=do_timeseries)
 
 
 @log_error_details()
@@ -1436,12 +1408,11 @@ def main():
         job_name = os.environ["JOB_NAME"]
         region = os.environ["REGION"]
         AwsBatch.run_job(job_id, s3_bucket, s3_prefix, job_name, region)
-    elif get_bool_env_var("POSTPROCESSING_INSIDE_DOCKER_CONTAINER"):
-        parser = argparse.ArgumentParser()
-        parser.add_argument("project_filename")
-        args = parser.parse_args()
-        batch = AwsBatch(args.project_filename)
-        batch._process_results_inside_container()
+    elif os.environ.get("JOB_TYPE") == "POSTPROCESS":
+        s3_bucket = os.environ["S3_BUCKET"]
+        s3_prefix = os.environ["S3_PREFIX"]
+        do_timeseries = os.environ.get("DO_TIMESERIES", "False") == "True"
+        AwsBatch.run_combine_results_on_cloud(s3_bucket, s3_prefix, do_timeseries)
     else:
         parser = argparse.ArgumentParser()
         parser.add_argument("project_filename")

--- a/buildstockbatch/aws/aws.py
+++ b/buildstockbatch/aws/aws.py
@@ -1250,7 +1250,7 @@ class AwsBatch(docker_base.DockerBatchBase):
         jobs_file_path = sim_dir.parent / "jobs.tar.gz"
         s3.download_file(bucket, f"{prefix}/jobs.tar.gz", str(jobs_file_path))
         with tarfile.open(jobs_file_path, "r") as tar_f:
-            jobs_d = json.load(tar_f.extractfile(f"jobs/job{job_id:05d}.json"), encoding="utf-8")
+            jobs_d = json.load(tar_f.extractfile(f"jobs/job{job_id:05d}.json"))
         logger.debug("Number of simulations = {}".format(len(jobs_d["batch"])))
 
         logger.debug("Getting weather files")

--- a/buildstockbatch/aws/aws.py
+++ b/buildstockbatch/aws/aws.py
@@ -33,6 +33,7 @@ import io
 
 from buildstockbatch import postprocessing
 from buildstockbatch.aws.awsbase import AwsJobBase, boto_client_config
+from buildstockbatch.base import ValidationError
 from buildstockbatch.cloud import docker_base
 from buildstockbatch.utils import (
     log_error_details,
@@ -1008,8 +1009,13 @@ class AwsBatch(docker_base.DockerBatchBase):
     DEFAULT_PP_VCPUS = 4
     DEFAULT_PP_MEMORY_MIB = 30720
 
-    def __init__(self, project_filename):
-        super().__init__(project_filename)
+    def __init__(self, project_filename, missing_only=False):
+        """
+        :param project_filename: Path to the project's configuration file.
+        :param missing_only: If true, use asset files from a previous job and only run the
+            simulation batches that don't already have results from a previous run.
+        """
+        super().__init__(project_filename, missing_only)
 
         self.job_identifier = re.sub("[^0-9a-zA-Z]+", "_", self.cfg["aws"]["job_identifier"])[:10]
 
@@ -1153,6 +1159,7 @@ class AwsBatch(docker_base.DockerBatchBase):
             S3_PREFIX=self.s3_bucket_prefix,
             JOB_NAME=self.job_identifier,
             REGION=self.region,
+            MISSING_ONLY=str(self.missing_only),
         )
 
         job_env_cfg = self.cfg["aws"].get("job_environment", {})
@@ -1164,12 +1171,26 @@ class AwsBatch(docker_base.DockerBatchBase):
             env_vars=env_vars,
         )
 
-        # start job
-        job_info = batch_env.submit_job(array_size=self.batch_array_size)
+        if self.missing_only:
+            # Save a list of task numbers to rerun in a file on S3. Task i of the new array job
+            # will read line i of this file to find the task of the original job it should rerun.
+            n_tasks = self.find_missing_tasks(batch_info.job_count)
+            if not n_tasks:
+                raise ValidationError(
+                    f"There are no tasks to retry. All {batch_info.job_count} results files are present."
+                )
+            logger.info(f"Found {n_tasks} out of {batch_info.job_count} tasks to rerun.")
+        else:
+            n_tasks = batch_info.job_count
+
+        # start job. AWS Batch requires array jobs to have at least 2 tasks; tasks with no
+        # assigned batch of simulations exit without doing anything.
+        array_size = max(n_tasks, 2)
+        job_info = batch_env.submit_job(array_size=array_size)
 
         # Monitor job status
         n_succeeded_last_time = 0
-        with tqdm.tqdm(desc="Running Simulations", total=self.batch_array_size) as progress_bar:
+        with tqdm.tqdm(desc="Running Simulations", total=array_size) as progress_bar:
             job_status = None
             while job_status not in ("SUCCEEDED", "FAILED"):
                 time.sleep(10)
@@ -1195,17 +1216,32 @@ class AwsBatch(docker_base.DockerBatchBase):
             raise RuntimeError("Batch Job Failed. Go look at the CloudWatch logs.")
 
     @classmethod
-    def run_job(cls, job_id, bucket, prefix, job_name, region):
+    def run_job(cls, job_id, bucket, prefix, job_name, region, missing_only=False):
         """
         Run a few simulations inside a container.
 
         This method is called from inside docker container in AWS. It will
         go get the necessary files from S3, run the simulation, and post the
         results back to S3.
+
+        :param missing_only: If True, rerun a task from a previous job. The provided job_id is
+            used as an index into the list of tasks that need to be rerun.
         """
 
         logger.debug(f"region: {region}")
         s3 = boto3.client("s3", config=boto_client_config)
+
+        if missing_only:
+            # Find the task number of the original task we're retrying.
+            with io.BytesIO() as f:
+                s3.download_fileobj(bucket, f"{prefix}/results/missing_tasks.txt", f)
+                tasks = f.getvalue().decode().split()
+            if job_id >= len(tasks):
+                # Extra task from padding the array job to AWS Batch's two-task minimum
+                logger.info(f"No missing task at index {job_id}; nothing to do.")
+                return
+            job_id = int(tasks[job_id])
+            logger.info(f"Rerunning task {job_id}")
 
         sim_dir = pathlib.Path("/var/simdata/openstudio")
 
@@ -1225,7 +1261,12 @@ class AwsBatch(docker_base.DockerBatchBase):
         jobs_file_path = sim_dir.parent / "jobs.tar.gz"
         s3.download_file(bucket, f"{prefix}/jobs.tar.gz", str(jobs_file_path))
         with tarfile.open(jobs_file_path, "r") as tar_f:
-            jobs_d = json.load(tar_f.extractfile(f"jobs/job{job_id:05d}.json"))
+            try:
+                jobs_d = json.load(tar_f.extractfile(f"jobs/job{job_id:05d}.json"))
+            except KeyError:
+                # Extra task from padding the array job to AWS Batch's two-task minimum
+                logger.info(f"No job file for task {job_id}; nothing to do.")
+                return
         logger.debug("Number of simulations = {}".format(len(jobs_d["batch"])))
 
         logger.debug("Getting weather files")
@@ -1407,7 +1448,8 @@ def main():
         s3_prefix = os.environ["S3_PREFIX"]
         job_name = os.environ["JOB_NAME"]
         region = os.environ["REGION"]
-        AwsBatch.run_job(job_id, s3_bucket, s3_prefix, job_name, region)
+        missing_only = os.environ.get("MISSING_ONLY") == "True"
+        AwsBatch.run_job(job_id, s3_bucket, s3_prefix, job_name, region, missing_only)
     elif os.environ.get("JOB_TYPE") == "POSTPROCESS":
         s3_bucket = os.environ["S3_BUCKET"]
         s3_prefix = os.environ["S3_PREFIX"]
@@ -1438,6 +1480,13 @@ def main():
             help="Only do the crawling in Athena. When simulations and postprocessing are done.",
             action="store_true",
         )
+        group.add_argument(
+            "--missingonly",
+            action="store_true",
+            help="Only run batches of simulations that are missing results from a previous job, then run "
+            "post-processing. Assumes that the project file is the same as the previous job. Will not rerun "
+            "individual failed simulations, only full batches that are missing results.",
+        )
         args = parser.parse_args()
 
         # validate the project, and in case of the --validateonly flag return True if validation passes
@@ -1445,7 +1494,7 @@ def main():
         if args.validateonly:
             return
 
-        batch = AwsBatch(args.project_filename)
+        batch = AwsBatch(args.project_filename, missing_only=args.missingonly)
         if args.clean:
             batch.clean()
         elif args.postprocessonly:

--- a/buildstockbatch/aws/aws.py
+++ b/buildstockbatch/aws/aws.py
@@ -43,6 +43,7 @@ from buildstockbatch.utils import (
     log_error_details,
     get_project_configuration,
     get_bool_env_var,
+    path_rel_to_file,
 )
 
 logger = logging.getLogger(__name__)
@@ -1283,9 +1284,14 @@ class AwsBatch(docker_base.DockerBatchBase):
         existing_vpc = self.cfg["aws"].get("vpc")
         if existing_vpc:
             fargate_vpc_kwargs["vpc"] = existing_vpc["vpc_id"]
-            fargate_vpc_kwargs["subnets"] = existing_vpc["subnet_ids"]
+            # The dask scheduler must be reachable from the machine running postprocessing,
+            # so its subnets (public, internet-gateway-routed) may differ from the Batch ones.
+            fargate_vpc_kwargs["subnets"] = existing_vpc.get("dask_subnet_ids", existing_vpc["subnet_ids"])
             if existing_vpc.get("security_group_id"):
                 fargate_vpc_kwargs["security_groups"] = [existing_vpc["security_group_id"]]
+            # dask_cloudprovider's stale-resource sweep deletes security groups by name,
+            # which only works in the default VPC; it crashes on groups in other VPCs.
+            fargate_vpc_kwargs["skip_cleanup"] = True
         self.dask_cluster = FargateCluster(
             region_name=self.region,
             fargate_spot=True,
@@ -1321,6 +1327,14 @@ class AwsBatch(docker_base.DockerBatchBase):
             cfg["buildstock_directory"] = container_buildstock_dir
             cfg["project_directory"] = str(pathlib.Path(self.project_dir).relative_to(self.buildstock_dir))
 
+            # Make a precomputed sample file available inside the container, where it is
+            # re-validated relative to the project config file's location.
+            sampler_args = cfg.get("sampler", {}).get("args", {})
+            if "sample_file" in sampler_args:
+                sample_file = path_rel_to_file(self.project_filename, sampler_args["sample_file"])
+                shutil.copy(sample_file, tmppath / "buildstock.csv")
+                sampler_args["sample_file"] = "buildstock.csv"
+
             with open(tmppath / "project_config.yml", "w") as f:
                 f.write(yaml.dump(cfg, Dumper=yaml.SafeDumper))
             container_cfg_path = str(container_workpath / "project_config.yml")
@@ -1352,11 +1366,16 @@ class AwsBatch(docker_base.DockerBatchBase):
                 },
                 environment=env,
                 name="bsb_post",
-                auto_remove=True,
                 detach=True,
             )
-            for msg in container.logs(stream=True):
-                logger.debug(msg)
+            try:
+                for msg in container.logs(stream=True):
+                    logger.debug(msg)
+                result = container.wait()
+            finally:
+                container.remove(force=True)
+            if result.get("StatusCode", 1) != 0:
+                raise RuntimeError(f"Postprocessing failed. The bsb_post container exited with {result}")
 
     def _process_results_inside_container(self):
         with open("/var/simdata/openstudio/args.json", "r") as f:

--- a/buildstockbatch/aws/aws.py
+++ b/buildstockbatch/aws/aws.py
@@ -189,6 +189,12 @@ class AwsBatchEnv(AwsJobBase):
 
         logger.info(f"Security group {self.batch_security_group} created for vpc/job.")
 
+        backoff(
+            self.ec2.create_tags,
+            Resources=[self.batch_security_group],
+            Tags=self.get_tags_uppercase(Name=self.job_identifier),
+        )
+
         response = backoff(
             self.ec2.authorize_security_group_ingress,
             GroupId=self.batch_security_group,
@@ -396,6 +402,7 @@ class AwsBatchEnv(AwsJobBase):
             "batch",
             f"Service role for Batch environment {self.job_identifier}",
             managed_policie_arns=["arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"],
+            tags=self.get_tags_uppercase(),
         )
 
         # Instance Role for Batch compute environment
@@ -405,12 +412,16 @@ class AwsBatchEnv(AwsJobBase):
             "ec2",
             f"Instance role for Batch compute environment {self.job_identifier}",
             managed_policie_arns=["arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"],
+            tags=self.get_tags_uppercase(),
         )
 
         # Instance Profile
 
         try:
-            response = self.iam.create_instance_profile(InstanceProfileName=self.batch_instance_profile_name)
+            response = self.iam.create_instance_profile(
+                InstanceProfileName=self.batch_instance_profile_name,
+                Tags=self.get_tags_uppercase(),
+            )
 
             self.instance_profile_arn = response["InstanceProfile"]["Arn"]
 
@@ -521,6 +532,7 @@ class AwsBatchEnv(AwsJobBase):
             "ecs-tasks",
             f"Task role for Batch job {self.job_identifier}",
             policies_list=[task_permissions_policy],
+            tags=self.get_tags_uppercase(),
         )
 
         if self.batch_use_spot:
@@ -530,6 +542,7 @@ class AwsBatchEnv(AwsJobBase):
                 "spotfleet",
                 f"Spot Fleet role for Batch compute environment {self.job_identifier}",
                 managed_policie_arns=["arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole"],
+                tags=self.get_tags_uppercase(),
             )
 
     def create_compute_environment(self, maxCPUs=10000):
@@ -693,6 +706,7 @@ class AwsBatchEnv(AwsJobBase):
                 "environment": self.generate_name_value_inputs(env_vars),
             },
             retryStrategy={"attempts": 2},
+            propagateTags=True,
             tags=self.get_tags(),
         )
 
@@ -1017,7 +1031,8 @@ class AwsBatch(docker_base.DockerBatchBase):
             if repo["repositoryName"] == repo_name:
                 break
         if repo is None:
-            resp = self.ecr.create_repository(repositoryName=repo_name)
+            tags = [{"Key": k, "Value": v} for k, v in self.cfg["aws"].get("tags", {}).items()]
+            resp = self.ecr.create_repository(repositoryName=repo_name, tags=tags)
             repo = resp["repository"]
         return repo
 

--- a/buildstockbatch/aws/aws.py
+++ b/buildstockbatch/aws/aws.py
@@ -145,6 +145,28 @@ class AwsBatchEnv(AwsJobBase):
         return super().__repr__()
 
     def create_vpc(self):
+        existing_vpc = self.aws_config.get("vpc")
+        if existing_vpc:
+            # Use an existing VPC rather than creating one (for accounts where VPC
+            # creation is not permitted). Nothing in the VPC is created or modified.
+            self.vpc_id = existing_vpc["vpc_id"]
+            self.batch_subnet_ids = existing_vpc["subnet_ids"]
+            security_group_id = existing_vpc.get("security_group_id")
+            if not security_group_id:
+                sec_response = self.ec2.describe_security_groups(
+                    Filters=[
+                        {"Name": "vpc-id", "Values": [self.vpc_id]},
+                        {"Name": "group-name", "Values": ["default"]},
+                    ]
+                )
+                security_group_id = sec_response["SecurityGroups"][0]["GroupId"]
+            self.batch_security_group = security_group_id
+            logger.info(
+                f"Using existing VPC {self.vpc_id} with subnets {self.batch_subnet_ids} "
+                f"and security group {self.batch_security_group}"
+            )
+            return
+
         cidrs_in_use = set()
         vpc_response = self.ec2.describe_vpcs()
         for vpc in vpc_response["Vpcs"]:
@@ -231,6 +253,7 @@ class AwsBatchEnv(AwsJobBase):
         )
 
         self.priv_vpc_subnet_id_2 = priv_response_2["Subnet"]["SubnetId"]
+        self.batch_subnet_ids = [self.priv_vpc_subnet_id_1, self.priv_vpc_subnet_id_2]
 
         logger.info("Private subnet created.")
 
@@ -602,7 +625,7 @@ class AwsBatchEnv(AwsJobBase):
                 "launchTemplate": {
                     "launchTemplateName": self.launch_template_name,
                 },
-                "subnets": [self.priv_vpc_subnet_id_1, self.priv_vpc_subnet_id_2],
+                "subnets": self.batch_subnet_ids,
                 "securityGroupIds": [self.batch_security_group],
                 "instanceRole": self.instance_profile_arn,
             }
@@ -682,6 +705,19 @@ class AwsBatchEnv(AwsJobBase):
                 else:
                     raise
 
+        # Wait for the job queue to finish being created; submitting jobs to a
+        # queue that isn't in the VALID state yet fails.
+        for _ in range(60):
+            response = self.batch.describe_job_queues(jobQueues=[self.batch_job_queue_name])
+            queue_status = response["jobQueues"][0]["status"]
+            if queue_status == "VALID":
+                logger.info(f"Job queue {self.batch_job_queue_name} is ready")
+                break
+            logger.debug(f"Waiting for job queue {self.batch_job_queue_name} (status = {queue_status})")
+            time.sleep(5)
+        else:
+            raise RuntimeError(f"Job queue {self.batch_job_queue_name} did not reach the VALID state")
+
     def create_job_definition(self, docker_image, vcpus, memory, command, env_vars):
         """
         Creates a job definition to run in the Batch environment.  This will create a new version with every execution.
@@ -730,41 +766,44 @@ class AwsBatchEnv(AwsJobBase):
         return resp
 
     def clean(self):
-        # Get our vpc:
+        # When using an existing VPC, don't touch it (or its security groups) during cleanup.
+        using_existing_vpc = bool(self.aws_config.get("vpc"))
 
-        response = self.ec2.describe_vpcs(
-            Filters=[
-                {
-                    "Name": "tag:Name",
-                    "Values": [
-                        self.vpc_name,
-                    ],
-                },
-            ]
-        )
-        try:
-            self.vpc_id = response["Vpcs"][0]["VpcId"]
-        except (KeyError, IndexError):
-            self.vpc_id = None
+        if not using_existing_vpc:
+            # Get our vpc:
+            response = self.ec2.describe_vpcs(
+                Filters=[
+                    {
+                        "Name": "tag:Name",
+                        "Values": [
+                            self.vpc_name,
+                        ],
+                    },
+                ]
+            )
+            try:
+                self.vpc_id = response["Vpcs"][0]["VpcId"]
+            except (KeyError, IndexError):
+                self.vpc_id = None
 
-        default_sg_response = self.ec2.describe_security_groups(
-            Filters=[
-                {
-                    "Name": "group-name",
-                    "Values": [
-                        "default",
-                    ],
-                },
-            ]
-        )
+            default_sg_response = self.ec2.describe_security_groups(
+                Filters=[
+                    {
+                        "Name": "group-name",
+                        "Values": [
+                            "default",
+                        ],
+                    },
+                ]
+            )
 
-        logger.info("Removing egress from default security group.")
-        for group in default_sg_response["SecurityGroups"]:
-            if group["VpcId"] == self.vpc_id:
-                default_group_id = group["GroupId"]
-                dsg = self.ec2r.SecurityGroup(default_group_id)
-                if len(dsg.ip_permissions_egress):
-                    response = dsg.revoke_egress(IpPermissions=dsg.ip_permissions_egress)
+            logger.info("Removing egress from default security group.")
+            for group in default_sg_response["SecurityGroups"]:
+                if group["VpcId"] == self.vpc_id:
+                    default_group_id = group["GroupId"]
+                    dsg = self.ec2r.SecurityGroup(default_group_id)
+                    if len(dsg.ip_permissions_egress):
+                        response = dsg.revoke_egress(IpPermissions=dsg.ip_permissions_egress)
 
         try:
             self.batch.update_job_queue(jobQueue=self.batch_job_queue_name, state="DISABLED")
@@ -829,18 +868,22 @@ class AwsBatchEnv(AwsJobBase):
 
         # Find Nat Gateways and VPCs
 
-        response = self.ec2.describe_vpcs(
-            Filters=[
-                {
-                    "Name": "tag:Name",
-                    "Values": [
-                        self.job_identifier,
-                    ],
-                },
-            ],
-        )
+        if using_existing_vpc:
+            vpcs_to_delete = []
+        else:
+            response = self.ec2.describe_vpcs(
+                Filters=[
+                    {
+                        "Name": "tag:Name",
+                        "Values": [
+                            self.job_identifier,
+                        ],
+                    },
+                ],
+            )
+            vpcs_to_delete = response["Vpcs"]
 
-        for vpc in response["Vpcs"]:
+        for vpc in vpcs_to_delete:
             this_vpc = vpc["VpcId"]
 
             s3gw_response = self.ec2.describe_vpc_endpoints(Filters=[{"Name": "vpc-id", "Values": [this_vpc]}])
@@ -1055,15 +1098,25 @@ class AwsBatch(docker_base.DockerBatchBase):
         image = self.docker_client.images.get(self.docker_image)
         image.tag(repo_url, tag=self.job_identifier)
         last_status = None
-        for x in self.docker_client.images.push(repo_url, tag=self.job_identifier, stream=True):
+        push_error = None
+        # Pass the credentials explicitly; otherwise the push resolves auth from the
+        # machine's docker credential store, which may hold an expired token for ECR.
+        auth_config = {"username": dkr_user, "password": dkr_pass}
+        for x in self.docker_client.images.push(
+            repo_url, tag=self.job_identifier, stream=True, auth_config=auth_config
+        ):
             try:
                 y = json.loads(x)
             except json.JSONDecodeError:
                 continue
-            else:
-                if y.get("status") is not None and y.get("status") != last_status:
-                    logger.debug(y["status"])
-                    last_status = y["status"]
+            if y.get("error") is not None:
+                push_error = y["error"]
+                logger.error(f"Error pushing docker image: {push_error}")
+            elif y.get("status") is not None and y.get("status") != last_status:
+                logger.debug(y["status"])
+                last_status = y["status"]
+        if push_error:
+            raise RuntimeError(f"Failed to push docker image {repo_url}:{self.job_identifier}: {push_error}")
 
     def clean(self):
         """
@@ -1225,6 +1278,13 @@ class AwsBatch(docker_base.DockerBatchBase):
 
         batch_env = AwsBatchEnv(self.job_identifier, self.cfg["aws"], self.boto3_session)
         m = 1024
+        fargate_vpc_kwargs = {}
+        existing_vpc = self.cfg["aws"].get("vpc")
+        if existing_vpc:
+            fargate_vpc_kwargs["vpc"] = existing_vpc["vpc_id"]
+            fargate_vpc_kwargs["subnets"] = existing_vpc["subnet_ids"]
+            if existing_vpc.get("security_group_id"):
+                fargate_vpc_kwargs["security_groups"] = [existing_vpc["security_group_id"]]
         self.dask_cluster = FargateCluster(
             region_name=self.region,
             fargate_spot=True,
@@ -1237,6 +1297,7 @@ class AwsBatch(docker_base.DockerBatchBase):
             n_workers=dask_cfg["n_workers"],
             task_role_policies=["arn:aws:iam::aws:policy/AmazonS3FullAccess"],
             tags=batch_env.get_tags(),
+            **fargate_vpc_kwargs,
         )
         self.dask_client = Client(self.dask_cluster)
         return self.dask_client

--- a/buildstockbatch/aws/aws.py
+++ b/buildstockbatch/aws/aws.py
@@ -994,6 +994,7 @@ class AwsBatch(docker_base.DockerBatchBase):
     def validate_project(project_file):
         super(AwsBatch, AwsBatch).validate_project(project_file)
         AwsBatch.validate_dask_settings(project_file)
+        AwsBatch.validate_base_dockerfile(project_file, "aws")
 
     @property
     def docker_image(self):
@@ -1114,7 +1115,7 @@ class AwsBatch(docker_base.DockerBatchBase):
         job_env_cfg = self.cfg["aws"].get("job_environment", {})
         batch_env.create_job_definition(
             self.image_url,
-            command=["python3", "-m", "buildstockbatch.aws.aws"],
+            command=[docker_base.CONTAINER_BUILDSTOCKBATCH_PYTHON, "-m", "buildstockbatch.aws.aws"],
             vcpus=job_env_cfg.get("vcpus", 1),
             memory=job_env_cfg.get("memory", 1024),
             env_vars=env_vars,
@@ -1262,7 +1263,7 @@ class AwsBatch(docker_base.DockerBatchBase):
             logger.info("Starting container for postprocessing")
             container = self.docker_client.containers.run(
                 self.image_url,
-                ["python3", "-m", "buildstockbatch.aws.aws", container_cfg_path],
+                [docker_base.CONTAINER_BUILDSTOCKBATCH_PYTHON, "-m", "buildstockbatch.aws.aws", container_cfg_path],
                 volumes={
                     tmpdir: {"bind": str(container_workpath), "mode": "rw"},
                     self.buildstock_dir: {"bind": container_buildstock_dir, "mode": "ro"},

--- a/buildstockbatch/aws/aws.py
+++ b/buildstockbatch/aws/aws.py
@@ -17,7 +17,7 @@ import docker
 from botocore.exceptions import ClientError
 from copy import deepcopy
 import csv
-from dask.distributed import Client
+from dask.distributed import Client, LocalCluster
 from dask_cloudprovider.aws import FargateCluster
 import gzip
 from joblib import Parallel, delayed
@@ -1277,6 +1277,15 @@ class AwsBatch(docker_base.DockerBatchBase):
 
     def get_dask_client(self):
         dask_cfg = self.cfg["aws"]["dask"]
+
+        if not dask_cfg.get("use_fargate_cluster", True):
+            # Run dask locally (inside the postprocessing container). Useful when the
+            # Fargate scheduler isn't reachable from the machine running postprocessing,
+            # e.g. from behind a corporate network that blocks the dask protocol.
+            logger.info("Using a local dask cluster for postprocessing")
+            self.dask_cluster = LocalCluster(n_workers=dask_cfg.get("n_workers", 2))
+            self.dask_client = Client(self.dask_cluster)
+            return self.dask_client
 
         batch_env = AwsBatchEnv(self.job_identifier, self.cfg["aws"], self.boto3_session)
         m = 1024

--- a/buildstockbatch/aws/aws.py
+++ b/buildstockbatch/aws/aws.py
@@ -13,6 +13,7 @@ This class contains the object & methods that allow for usage of the library wit
 import argparse
 import base64
 import boto3
+import docker
 from botocore.exceptions import ClientError
 from copy import deepcopy
 import csv
@@ -1337,6 +1338,11 @@ class AwsBatch(docker_base.DockerBatchBase):
             env["POSTPROCESSING_INSIDE_DOCKER_CONTAINER"] = "true"
 
             logger.info("Starting container for postprocessing")
+            # Remove a leftover container from a previous interrupted run
+            try:
+                self.docker_client.containers.get("bsb_post").remove(force=True)
+            except docker.errors.NotFound:
+                pass
             container = self.docker_client.containers.run(
                 self.image_url,
                 [docker_base.CONTAINER_BUILDSTOCKBATCH_PYTHON, "-m", "buildstockbatch.aws.aws", container_cfg_path],

--- a/buildstockbatch/aws/awsbase.py
+++ b/buildstockbatch/aws/awsbase.py
@@ -24,6 +24,7 @@ class AWSIAMHelper:
         description,
         policies_list=[],
         managed_policie_arns=[],
+        tags=None,
     ):
         """
         Creates a role and attached the policies - will catch errors and skip if role already exists
@@ -47,12 +48,16 @@ class AWSIAMHelper:
                     }}
                 """
 
+        create_role_kwargs = {}
+        if tags:
+            create_role_kwargs["Tags"] = tags
         try:
             response = self.iam.create_role(
                 Path="/",
                 RoleName=role_name,
                 AssumeRolePolicyDocument=trust_policy,
                 Description=description,
+                **create_role_kwargs,
             )
             role_arn = response["Role"]["Arn"]
 

--- a/buildstockbatch/aws/awsbase.py
+++ b/buildstockbatch/aws/awsbase.py
@@ -181,6 +181,7 @@ class AwsJobBase:
         self.priv_subnet_cidr_1 = ""  # will be available after VPC creation
         self.priv_vpc_subnet_id_1 = "REPL"  # will be available after VPC creation
         self.priv_vpc_subnet_id_2 = "REPL"  # will be available after VPC creation
+        self.batch_subnet_ids = []  # will be available after VPC creation or lookup
 
     def get_tags(self, **kwargs):
         tags = kwargs.copy()

--- a/buildstockbatch/cloud/docker_base.py
+++ b/buildstockbatch/cloud/docker_base.py
@@ -38,7 +38,6 @@ from buildstockbatch.utils import (
     calc_hash_for_file,
     compress_file,
     read_csv,
-    get_bool_env_var,
     get_project_configuration,
 )
 
@@ -129,11 +128,8 @@ class DockerBatchBase(BuildStockBatchBase):
         super().__init__(project_filename)
         self.missing_only = missing_only
 
-        if get_bool_env_var("POSTPROCESSING_INSIDE_DOCKER_CONTAINER"):
-            return
-
-        # Generous timeout: some operations (e.g. starting a container that bind-mounts a
-        # large directory through Docker Desktop's file sharing) can take several minutes.
+        # Generous timeout: some docker API operations (e.g. uploading a large build
+        # context through Docker Desktop's file sharing on Windows) can take several minutes.
         self.docker_client = docker.DockerClient.from_env(timeout=3600)
         try:
             self.docker_client.ping()

--- a/buildstockbatch/cloud/docker_base.py
+++ b/buildstockbatch/cloud/docker_base.py
@@ -12,6 +12,7 @@ This is the base class mixed into classes that deploy using a docker container.
 import collections
 import csv
 from dataclasses import dataclass
+import datetime as dt
 import docker
 from fsspec.implementations.local import LocalFileSystem
 import gzip
@@ -648,6 +649,12 @@ class DockerBatchBase(BuildStockBatchBase):
         asset_dirs = os.listdir(sim_dir)
         ts_output_dir = f"{output_path}/results/simulation_output/timeseries"
 
+        max_time_min = cfg.get("max_minutes_per_sim")
+        if max_time_min is not None:
+            subprocess_kw = {"timeout": max_time_min * 60}
+        else:
+            subprocess_kw = {}
+
         with tarfile.open(str(simulation_output_tar_filename), "w:gz") as simout_tar:
             for building_id, upgrade_idx in jobs_d["batch"]:
                 upgrade_id = 0 if upgrade_idx is None else upgrade_idx + 1
@@ -659,6 +666,7 @@ class DockerBatchBase(BuildStockBatchBase):
                     json.dump(osw, f, indent=4)
 
                 # Run Simulation
+                start_time = dt.datetime.now()
                 with open(sim_dir / "os_stdout.log", "w") as f_out:
                     try:
                         logger.debug("Running {}".format(sim_id))
@@ -683,7 +691,27 @@ class DockerBatchBase(BuildStockBatchBase):
                             stdout=f_out,
                             stderr=subprocess.STDOUT,
                             cwd=str(sim_dir),
+                            **subprocess_kw,
                         )
+                    except subprocess.TimeoutExpired:
+                        end_time = dt.datetime.now()
+                        msg = f"Terminated {sim_id} after reaching max time of {max_time_min} minutes"
+                        logger.warning(msg)
+                        f_out.write(msg)
+                        with open(sim_dir / "out.osw", "w") as out_osw:
+                            out_msg = {
+                                "started_at": start_time.strftime("%Y%m%dT%H%M%SZ"),
+                                "completed_at": end_time.strftime("%Y%m%dT%H%M%SZ"),
+                                "completed_status": "Fail",
+                                "timeout": msg,
+                            }
+                            out_osw.write(json.dumps(out_msg, indent=3))
+                        (sim_dir / "run").mkdir(exist_ok=True)
+                        with open(sim_dir / "run" / "run.log", "a") as run_log:
+                            run_log.write(f"[{end_time.strftime('%H:%M:%S')} ERROR] {msg}")
+                        with open(sim_dir / "run" / "failed.job", "w") as failed_job:
+                            failed_job.write(f"[{end_time.strftime('%H:%M:%S')} ERROR] {msg}")
+                        time.sleep(20)  # Wait for EnergyPlus to release file locks
                     except subprocess.CalledProcessError:
                         logger.debug(f"Simulation failed: see {sim_id}/os_stdout.log")
 

--- a/buildstockbatch/cloud/docker_base.py
+++ b/buildstockbatch/cloud/docker_base.py
@@ -132,7 +132,9 @@ class DockerBatchBase(BuildStockBatchBase):
         if get_bool_env_var("POSTPROCESSING_INSIDE_DOCKER_CONTAINER"):
             return
 
-        self.docker_client = docker.DockerClient.from_env()
+        # Generous timeout: some operations (e.g. starting a container that bind-mounts a
+        # large directory through Docker Desktop's file sharing) can take several minutes.
+        self.docker_client = docker.DockerClient.from_env(timeout=3600)
         try:
             self.docker_client.ping()
         except:  # noqa: E722 (allow bare except in this case because error can be a weird non-class Windows API error)

--- a/buildstockbatch/cloud/docker_base.py
+++ b/buildstockbatch/cloud/docker_base.py
@@ -33,9 +33,21 @@ import time
 
 from buildstockbatch import postprocessing
 from buildstockbatch.base import BuildStockBatchBase, ValidationError
-from buildstockbatch.utils import ContainerRuntime, calc_hash_for_file, compress_file, read_csv, get_bool_env_var
+from buildstockbatch.utils import (
+    ContainerRuntime,
+    calc_hash_for_file,
+    compress_file,
+    read_csv,
+    get_bool_env_var,
+    get_project_configuration,
+)
 
 logger = logging.getLogger(__name__)
+
+# Python interpreter with buildstockbatch installed inside the docker image built from this
+# repo's Dockerfile. Referenced explicitly because the base image's own interpreters
+# (python3, python3.11) take precedence on the image's PATH.
+CONTAINER_BUILDSTOCKBATCH_PYTHON = "/buildstock-batch/.venv/bin/python3"
 
 
 def determine_weather_files_needed_for_job(sim_dir, jobs_d):
@@ -163,6 +175,30 @@ class DockerBatchBase(BuildStockBatchBase):
         """
         raise NotImplementedError
 
+    @staticmethod
+    def validate_base_dockerfile(project_file, platform):
+        """
+        Validate the optional ``<platform>.base_dockerfile`` config, which must be a path to a
+        Dockerfile relative to the buildstock directory.
+
+        :param platform: String specifying the platform the image is built for. Must be "aws" or "gcp".
+        """
+        cfg = get_project_configuration(project_file)
+        base_dockerfile = cfg.get(platform, {}).get("base_dockerfile")
+        if base_dockerfile is None:
+            return True
+        if os.path.isabs(base_dockerfile):
+            raise ValidationError(
+                f"`{platform}.base_dockerfile` must be a path relative to `buildstock_directory`, "
+                f"got the absolute path {base_dockerfile}"
+            )
+        base_dockerfile_path = pathlib.Path(cfg["buildstock_directory"], base_dockerfile)
+        if not base_dockerfile_path.is_file():
+            raise ValidationError(
+                f"`{platform}.base_dockerfile` = {base_dockerfile}, but no file exists at {base_dockerfile_path}"
+            )
+        return True
+
     def build_image(self, platform):
         """
         Build the docker image to use in the batch simulation
@@ -179,54 +215,68 @@ class DockerBatchBase(BuildStockBatchBase):
         if not os.path.exists(local_log_dir):
             os.makedirs(local_log_dir)
 
+        buildargs = {"OS_VER": self.os_version, "CLOUD_PLATFORM": platform}
+
+        # If the project provides its own Dockerfile (e.g. ComStock's, which adds python
+        # dependencies its measures call at simulation time), build it first and use the
+        # resulting image as the base for the buildstockbatch image.
+        base_dockerfile = self.cfg.get(platform, {}).get("base_dockerfile")
+        if base_dockerfile:
+            base_dockerfile_path = pathlib.Path(self.buildstock_dir, base_dockerfile)
+            if not base_dockerfile_path.is_file():
+                raise ValidationError(
+                    f"`{platform}.base_dockerfile` = {base_dockerfile}, but no file exists at {base_dockerfile_path}"
+                )
+            base_target = self.cfg[platform].get("base_target")
+            base_image_tag = f"buildstockbatch-base-{platform}"
+            logger.info(f"Building base docker image from {base_dockerfile_path}, stage: {base_target}")
+            self._build_docker_image(
+                "base_build_image.log",
+                local_log_dir,
+                path=str(self.buildstock_dir),
+                # The dockerfile path is relative to the build context and must use forward slashes
+                dockerfile=base_dockerfile.replace("\\", "/"),
+                tag=base_image_tag,
+                target=base_target,
+            )
+            buildargs["BASE_IMAGE"] = base_image_tag
+
         # Determine whether or not to build the image with custom gems bundled in
+        stage = "buildstockbatch"
         if self.cfg.get("baseline", dict()).get("custom_gems", False):
-            # Ensure the custom Gemfile exists in the buildstock dir
-            local_gemfile_path = pathlib.Path(self.buildstock_dir, "resources", "Gemfile")
-            if not local_gemfile_path.exists():
-                raise AttributeError(f"baseline:custom_gems = True, but did not find Gemfile at {local_gemfile_path}")
+            if base_dockerfile:
+                # The base image is responsible for bundling the custom gems;
+                # `custom_gems` still controls the openstudio bundle arguments at run time.
+                logger.info(
+                    f"Skipping the custom gems Docker build stage because `{platform}.base_dockerfile` is set. "
+                    "The base image must provide the custom gems and Gemfile at /var/oscli."
+                )
+            else:
+                # Ensure the custom Gemfile exists in the buildstock dir
+                local_gemfile_path = pathlib.Path(self.buildstock_dir, "resources", "Gemfile")
+                if not local_gemfile_path.exists():
+                    raise AttributeError(
+                        f"baseline:custom_gems = True, but did not find Gemfile at {local_gemfile_path}"
+                    )
 
-            # Copy the custom Gemfile into the buildstockbatch repo
-            new_gemfile_path = root_path / "Gemfile"
-            shutil.copyfile(local_gemfile_path, new_gemfile_path)
-            logger.info(f"Copying custom Gemfile from {local_gemfile_path}")
+                # Copy the custom Gemfile into the buildstockbatch repo
+                new_gemfile_path = root_path / "Gemfile"
+                shutil.copyfile(local_gemfile_path, new_gemfile_path)
+                logger.info(f"Copying custom Gemfile from {local_gemfile_path}")
 
-            # Choose the custom-gems stage in the Dockerfile,
-            # which runs bundle install to build custom gems into the image
-            stage = "buildstockbatch-custom-gems"
-        else:
-            # Choose the base stage in the Dockerfile,
-            # which stops before bundling custom gems into the image
-            stage = "buildstockbatch"
+                # Choose the custom-gems stage in the Dockerfile,
+                # which runs bundle install to build custom gems into the image
+                stage = "buildstockbatch-custom-gems"
 
         logger.info(f"Building docker image stage: {stage} from OpenStudio {self.os_version}")
-        try:
-            img, build_logs = self.docker_client.images.build(
-                path=str(root_path),
-                tag=self.docker_image,
-                rm=True,
-                target=stage,
-                platform="linux/amd64",
-                buildargs={"OS_VER": self.os_version, "CLOUD_PLATFORM": platform},
-            )
-        except docker.errors.BuildError as e:
-            for line in e.build_log:
-                if "stream" in line:
-                    logger.error(line["stream"].strip())
-                elif "errorDetail" in line:
-                    logger.error(f"Error: {line['errorDetail']['message'].strip()}")
-            raise
-        build_image_log = os.path.join(local_log_dir, "build_image.log")
-        with open(build_image_log, "w") as f_out:
-            f_out.write("Built image")
-            for line in build_logs:
-                for itm_type, item_msg in line.items():
-                    if itm_type in ["stream", "status"]:
-                        try:
-                            f_out.write(f"{item_msg}")
-                        except UnicodeEncodeError:
-                            pass
-        logger.debug(f"Review docker image build log: {build_image_log}")
+        self._build_docker_image(
+            "build_image.log",
+            local_log_dir,
+            path=str(root_path),
+            tag=self.docker_image,
+            target=stage,
+            buildargs=buildargs,
+        )
 
         # Report and confirm the openstudio version from the image
         os_ver_cmd = "openstudio openstudio_version"
@@ -256,6 +306,37 @@ class DockerBatchBase(BuildStockBatchBase):
         for line in container_output.decode().split("\n"):
             logger.debug(line)
         logger.debug(f"Review custom gems list at: {gem_list_log}")
+
+    def _build_docker_image(self, log_filename, local_log_dir, **build_kwargs):
+        """
+        Run a docker build, writing the build output to a log file.
+
+        :param log_filename: Name of the log file to write in ``local_log_dir``.
+        :param local_log_dir: Directory in which to write the log file.
+        :param build_kwargs: Keyword arguments passed through to ``docker.images.build``.
+        :returns: The built docker image.
+        """
+        try:
+            img, build_logs = self.docker_client.images.build(rm=True, platform="linux/amd64", **build_kwargs)
+        except docker.errors.BuildError as e:
+            for line in e.build_log:
+                if "stream" in line:
+                    logger.error(line["stream"].strip())
+                elif "errorDetail" in line:
+                    logger.error(f"Error: {line['errorDetail']['message'].strip()}")
+            raise
+        build_image_log = os.path.join(local_log_dir, log_filename)
+        with open(build_image_log, "w") as f_out:
+            f_out.write("Built image")
+            for line in build_logs:
+                for itm_type, item_msg in line.items():
+                    if itm_type in ["stream", "status"]:
+                        try:
+                            f_out.write(f"{item_msg}")
+                        except UnicodeEncodeError:
+                            pass
+        logger.debug(f"Review docker image build log: {build_image_log}")
+        return img
 
     def start_batch_job(self, batch_info):
         """Create and start the Batch job on the cloud.

--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -768,7 +768,7 @@ Results output browser (Cloud Console):
         jobs_file_path = sim_dir.parent / "jobs.tar.gz"
         bucket.blob(f"{gcs_prefix}/jobs.tar.gz").download_to_filename(jobs_file_path)
         with tarfile.open(jobs_file_path, "r") as tar_f:
-            jobs_d = json.load(tar_f.extractfile(f"jobs/job{task_index:05d}.json"), encoding="utf-8")
+            jobs_d = json.load(tar_f.extractfile(f"jobs/job{task_index:05d}.json"))
         logger.debug("Number of simulations = {}".format(len(jobs_d["batch"])))
 
         logger.debug("Getting weather files")

--- a/buildstockbatch/gcp/gcp.py
+++ b/buildstockbatch/gcp/gcp.py
@@ -563,7 +563,10 @@ class GcpBatch(DockerBatchBase):
         }
         bsb_runnable.environment = environment
 
-        bsb_runnable.container.commands = ["-c", "python3 -m buildstockbatch.gcp.gcp"]
+        bsb_runnable.container.commands = [
+            "-c",
+            f"{docker_base.CONTAINER_BUILDSTOCKBATCH_PYTHON} -m buildstockbatch.gcp.gcp",
+        ]
 
         gcp_cfg = self.cfg["gcp"]
         job_env_cfg = gcp_cfg.get("job_environment", {})
@@ -871,7 +874,7 @@ Results output browser (Cloud Console):
                                 }
                             ),
                             command=["/bin/sh"],
-                            args=["-c", "python3 -m buildstockbatch.gcp.gcp"],
+                            args=["-c", f"{docker_base.CONTAINER_BUILDSTOCKBATCH_PYTHON} -m buildstockbatch.gcp.gcp"],
                             env=[
                                 run_v2.EnvVar(name="JOB_TYPE", value="POSTPROCESS"),
                                 run_v2.EnvVar(name="GCS_PREFIX", value=self.gcs_prefix),

--- a/buildstockbatch/schemas/v0.6.yaml
+++ b/buildstockbatch/schemas/v0.6.yaml
@@ -66,27 +66,22 @@ aws-spec:
   spot_bid_percent: num(min=1, max=100, required=False)
   batch_array_size: num(min=1, max=10000, required=True)
   notifications_email: regex('^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$', name='email', required=True)
-  dask: include('aws-dask-spec', required=True)
   job_environment: include('aws-job-environment', required=False)
+  postprocessing_environment: include('aws-postprocessing-environment-spec', required=False)
   tags: map(str(), str(), required=False)
 
 aws-job-environment:
   vcpus: int(min=1, max=36, required=False)
   memory: int(min=1024, required=False)
 
+aws-postprocessing-environment-spec:
+  vcpus: int(min=1, max=36, required=False)
+  memory: int(min=1024, required=False)
+
 aws-vpc-spec:
   vpc_id: str(required=True)
   subnet_ids: list(str(), min=1, required=True)
-  dask_subnet_ids: list(str(), min=1, required=False)
   security_group_id: str(required=False)
-
-aws-dask-spec:
-  use_fargate_cluster: bool(required=False)
-  scheduler_cpu: enum(1024, 2048, 4096, 8192, 16384, required=False)
-  scheduler_memory: int(min=1024, required=False)
-  worker_cpu: enum(1024, 2048, 4096, 8192, 16384, required=False)
-  worker_memory: int(min=1024, required=False)
-  n_workers: int(min=1, required=True)
 
 hpc-spec:
   account: str(required=True)

--- a/buildstockbatch/schemas/v0.6.yaml
+++ b/buildstockbatch/schemas/v0.6.yaml
@@ -61,6 +61,7 @@ aws-spec:
   region: str(required=True)
   base_dockerfile: str(required=False)
   base_target: str(required=False)
+  vpc: include('aws-vpc-spec', required=False)
   use_spot: bool(required=False)
   spot_bid_percent: num(min=1, max=100, required=False)
   batch_array_size: num(min=1, max=10000, required=True)
@@ -72,6 +73,11 @@ aws-spec:
 aws-job-environment:
   vcpus: int(min=1, max=36, required=False)
   memory: int(min=1024, required=False)
+
+aws-vpc-spec:
+  vpc_id: str(required=True)
+  subnet_ids: list(str(), min=1, required=True)
+  security_group_id: str(required=False)
 
 aws-dask-spec:
   scheduler_cpu: enum(1024, 2048, 4096, 8192, 16384, required=False)

--- a/buildstockbatch/schemas/v0.6.yaml
+++ b/buildstockbatch/schemas/v0.6.yaml
@@ -77,6 +77,7 @@ aws-job-environment:
 aws-vpc-spec:
   vpc_id: str(required=True)
   subnet_ids: list(str(), min=1, required=True)
+  dask_subnet_ids: list(str(), min=1, required=False)
   security_group_id: str(required=False)
 
 aws-dask-spec:

--- a/buildstockbatch/schemas/v0.6.yaml
+++ b/buildstockbatch/schemas/v0.6.yaml
@@ -81,6 +81,7 @@ aws-vpc-spec:
   security_group_id: str(required=False)
 
 aws-dask-spec:
+  use_fargate_cluster: bool(required=False)
   scheduler_cpu: enum(1024, 2048, 4096, 8192, 16384, required=False)
   scheduler_memory: int(min=1024, required=False)
   worker_cpu: enum(1024, 2048, 4096, 8192, 16384, required=False)

--- a/buildstockbatch/schemas/v0.6.yaml
+++ b/buildstockbatch/schemas/v0.6.yaml
@@ -59,6 +59,8 @@ aws-spec:
   job_identifier: regex('^[a-zA-Z]\w{,9}$', required=True)
   s3: include('s3-aws-postprocessing-spec', required=True)
   region: str(required=True)
+  base_dockerfile: str(required=False)
+  base_target: str(required=False)
   use_spot: bool(required=False)
   spot_bid_percent: num(min=1, max=100, required=False)
   batch_array_size: num(min=1, max=10000, required=True)

--- a/buildstockbatch/test/test_docker_base.py
+++ b/buildstockbatch/test/test_docker_base.py
@@ -8,6 +8,7 @@ import os
 import pathlib
 import pytest
 import shutil
+import subprocess
 import tarfile
 import tempfile
 from unittest.mock import MagicMock, PropertyMock
@@ -186,6 +187,56 @@ def test_run_simulations(basic_residential_project_file):
 
         # Check that files were cleaned up correctly
         assert not os.listdir(sim_dir)
+        os.chdir(old_cwd)
+
+
+def test_run_simulations_timeout(basic_residential_project_file, mocker):
+    """A simulation that exceeds ``max_minutes_per_sim`` is terminated, recorded as failed,
+    and the worker moves on to the next simulation in its batch."""
+    jobs_d = {
+        "job_num": 0,
+        "n_datapoints": 10,
+        "batch": [
+            [1, None],
+            [5, None],
+        ],
+    }
+    fs = LocalFileSystem()
+    project_filename, results_dir = basic_residential_project_file({"max_minutes_per_sim": 5})
+    cfg = get_project_configuration(project_filename)
+
+    run_mock = mocker.patch.object(
+        docker_base.subprocess,
+        "run",
+        side_effect=subprocess.TimeoutExpired(cmd="openstudio", timeout=5 * 60),
+    )
+    sleep_mock = mocker.patch.object(docker_base.time, "sleep")
+
+    with tempfile.TemporaryDirectory(prefix="bsb_") as temp_dir_str:
+        temp_path = pathlib.Path(temp_dir_str)
+        sim_dir = temp_path / "simdata" / "openstudio"
+        os.makedirs(sim_dir)
+        old_cwd = os.getcwd()
+        os.chdir(sim_dir)
+        bucket = temp_path / "bucket"
+        os.makedirs(bucket / "test_prefix" / "results" / "simulation_output")
+
+        DockerBatchBase.run_simulations(cfg, 0, jobs_d, sim_dir, fs, f"{bucket}/test_prefix")
+
+        # Both simulations were attempted with the timeout, despite the first one timing out
+        assert run_mock.call_count == 2
+        for call in run_mock.call_args_list:
+            assert call.kwargs["timeout"] == 5 * 60
+        assert sleep_mock.call_count == 2
+
+        # Both simulations are recorded as failed
+        output_dir = bucket / "test_prefix" / "results" / "simulation_output"
+        with gzip.open(output_dir / "results_job0.json.gz", "r") as f:
+            results = json.load(f)
+        assert len(results) == 2
+        for building in results:
+            assert building["building_id"] in (1, 5)
+            assert building["completed_status"] == "Fail"
         os.chdir(old_cwd)
 
 

--- a/buildstockbatch/test/test_docker_base.py
+++ b/buildstockbatch/test/test_docker_base.py
@@ -12,6 +12,7 @@ import tarfile
 import tempfile
 from unittest.mock import MagicMock, PropertyMock
 
+from buildstockbatch.base import ValidationError
 from buildstockbatch.cloud import docker_base
 from buildstockbatch.cloud.docker_base import DockerBatchBase
 from buildstockbatch.test.shared_testing_stuff import docker_available
@@ -225,3 +226,101 @@ def test_log_summary(basic_residential_project_file, mocker, caplog):
         assert "Upgrade 01   Success: 3        Fail: 1" in caplog.text
         assert "Baseline     Success: 3        Fail: 1" in caplog.text
         assert "Total        Success: 6        Fail: 2" in caplog.text
+
+
+def _mock_docker_client(mocker, os_version):
+    """Mock the docker client so build_image tests don't require a docker daemon."""
+    docker_client = MagicMock()
+    docker_client.images.build.return_value = (MagicMock(), [])
+    docker_client.containers.run.return_value = f"OpenStudio {os_version}".encode()
+    mocker.patch.object(docker_base.docker.DockerClient, "from_env", return_value=docker_client)
+    return docker_client
+
+
+def test_build_image_no_base_dockerfile(basic_residential_project_file, mocker):
+    """Without ``<platform>.base_dockerfile``, build_image performs a single build from the stock base image."""
+    project_filename, _ = basic_residential_project_file(update_args={"os_version": "3.10.0"})
+    docker_client = _mock_docker_client(mocker, "3.10.0")
+
+    dbb = DockerBatchBase(project_filename)
+    dbb.build_image("aws")
+
+    assert docker_client.images.build.call_count == 1
+    build_kwargs = docker_client.images.build.call_args.kwargs
+    assert build_kwargs["target"] == "buildstockbatch"
+    assert build_kwargs["buildargs"] == {"OS_VER": "3.10.0", "CLOUD_PLATFORM": "aws"}
+
+
+def test_build_image_with_base_dockerfile(basic_residential_project_file, mocker):
+    """With ``<platform>.base_dockerfile``, the project's Dockerfile is built first and used as the base image,
+    and the custom-gems build stage is skipped even when ``custom_gems`` is on."""
+    project_filename, _ = basic_residential_project_file(
+        update_args={
+            "os_version": "3.10.0",
+            "baseline": {"custom_gems": True, "n_buildings_represented": 80000000},
+            "aws": {"base_dockerfile": "build/Dockerfile", "base_target": "os-comstock"},
+        }
+    )
+    cfg = get_project_configuration(project_filename)
+    buildstock_directory = cfg["buildstock_directory"]
+    os.makedirs(os.path.join(buildstock_directory, "build"))
+    with open(os.path.join(buildstock_directory, "build", "Dockerfile"), "w") as f:
+        f.write("FROM ubuntu:22.04 as os-comstock\n")
+
+    docker_client = _mock_docker_client(mocker, "3.10.0")
+
+    dbb = DockerBatchBase(project_filename)
+    dbb.build_image("aws")
+
+    assert docker_client.images.build.call_count == 2
+
+    base_kwargs = docker_client.images.build.call_args_list[0].kwargs
+    assert base_kwargs["path"] == str(dbb.buildstock_dir)
+    assert base_kwargs["dockerfile"] == "build/Dockerfile"
+    assert base_kwargs["target"] == "os-comstock"
+
+    main_kwargs = docker_client.images.build.call_args_list[1].kwargs
+    assert main_kwargs["buildargs"]["BASE_IMAGE"] == base_kwargs["tag"]
+    assert main_kwargs["buildargs"]["OS_VER"] == "3.10.0"
+    assert main_kwargs["target"] == "buildstockbatch"
+
+
+def test_build_image_missing_base_dockerfile(basic_residential_project_file, mocker):
+    """build_image fails cleanly if ``<platform>.base_dockerfile`` doesn't exist."""
+    project_filename, _ = basic_residential_project_file(
+        update_args={
+            "os_version": "3.10.0",
+            "aws": {"base_dockerfile": "build/Dockerfile"},
+        }
+    )
+    _mock_docker_client(mocker, "3.10.0")
+
+    dbb = DockerBatchBase(project_filename)
+    with pytest.raises(ValidationError, match="base_dockerfile"):
+        dbb.build_image("aws")
+
+
+def test_validate_base_dockerfile(basic_residential_project_file):
+    """validate_base_dockerfile passes when the file exists (or isn't configured) and fails when it doesn't."""
+    project_filename, _ = basic_residential_project_file(update_args={"aws": {"base_dockerfile": "build/Dockerfile"}})
+
+    with pytest.raises(ValidationError, match="base_dockerfile"):
+        DockerBatchBase.validate_base_dockerfile(project_filename, "aws")
+
+    cfg = get_project_configuration(project_filename)
+    os.makedirs(os.path.join(cfg["buildstock_directory"], "build"))
+    with open(os.path.join(cfg["buildstock_directory"], "build", "Dockerfile"), "w") as f:
+        f.write("FROM ubuntu:22.04\n")
+    assert DockerBatchBase.validate_base_dockerfile(project_filename, "aws")
+
+
+def test_validate_base_dockerfile_not_set(basic_residential_project_file):
+    project_filename, _ = basic_residential_project_file()
+    assert DockerBatchBase.validate_base_dockerfile(project_filename, "aws")
+
+
+def test_validate_base_dockerfile_absolute_path(basic_residential_project_file):
+    abs_path = os.path.join(here, "Dockerfile")
+    project_filename, _ = basic_residential_project_file(update_args={"aws": {"base_dockerfile": abs_path}})
+    with pytest.raises(ValidationError, match="relative"):
+        DockerBatchBase.validate_base_dockerfile(project_filename, "aws")

--- a/buildstockbatch/test/test_validation.py
+++ b/buildstockbatch/test/test_validation.py
@@ -63,7 +63,6 @@ def test_local_docker_validation_is_classmethod():
 
 def test_aws_batch_validation_is_static():
     assert isinstance(AwsBatch.validate_project, types.FunctionType)
-    assert isinstance(AwsBatch.validate_dask_settings, types.FunctionType)
 
 
 def test_complete_schema_passes_validation():
@@ -474,38 +473,6 @@ def test_validate_workflow_gen_version_fail_mismatch(mocker):
     proj_filename = resstock_directory / "project_national" / "sdr_upgrades_amy2018.yml"
     with pytest.raises(ValidationError):
         BuildStockBatchBase.validate_resstock_or_comstock_version(str(proj_filename))
-
-
-def test_dask_config():
-    orig_filename = os.path.join(example_yml_dir, "minimal-schema.yml")
-    cfg = get_project_configuration(orig_filename)
-    with tempfile.TemporaryDirectory() as tmpdir:
-        cfg["aws"] = {
-            "dask": {
-                "scheduler_cpu": 1024,
-                "scheduler_memory": 2048,
-                "worker_cpu": 1024,
-                "worker_memory": 2048,
-                "n_workers": 1,
-            }
-        }
-        test1_filename = os.path.join(tmpdir, "test1.yml")
-        with open(test1_filename, "w") as f:
-            json.dump(cfg, f)
-        AwsBatch.validate_dask_settings(test1_filename)
-        cfg["aws"]["dask"]["scheduler_memory"] = 9 * 1024
-        test2_filename = os.path.join(tmpdir, "test2.yml")
-        with open(test2_filename, "w") as f:
-            json.dump(cfg, f)
-        with pytest.raises(ValidationError, match=r"between 2048 and 8192"):
-            AwsBatch.validate_dask_settings(test2_filename)
-        cfg["aws"]["dask"]["scheduler_memory"] = 8 * 1024
-        cfg["aws"]["dask"]["worker_memory"] = 1025
-        test3_filename = os.path.join(tmpdir, "test3.yml")
-        with open(test3_filename, "w") as f:
-            json.dump(cfg, f)
-        with pytest.raises(ValidationError, match=r"needs to be a multiple of 1024"):
-            AwsBatch.validate_dask_settings(test3_filename)
 
 
 def test_validate_kestrel_output_directory():

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -116,3 +116,25 @@ Development Changelog
         IAM roles, the Batch instance profile, the ECR repository, and the Batch security group.
         Job definitions now set ``propagateTags`` so the tags also reach the ECS tasks launched
         for each simulation job.
+
+    .. change::
+        :tags: aws, feature
+        :pullreq: 521
+
+        Adds an optional ``aws.vpc`` configuration (``vpc_id``, ``subnet_ids``, and optionally
+        ``security_group_id``) to run AWS Batch and the Fargate dask cluster in an existing VPC
+        instead of creating a new one. This supports accounts where ``ec2:CreateVpc`` is denied
+        by policy. When set, buildstockbatch does not create, modify, or delete anything in the
+        VPC, including during ``--clean``.
+
+    .. change::
+        :tags: aws, bugfix
+        :pullreq: 521
+
+        Fixes two AWS submission bugs: jobs were submitted immediately after the Batch job queue
+        was created, failing with "JobQueue not in VALID state" when the queue was still being
+        provisioned (buildstockbatch now waits for the queue to become VALID); and docker push
+        errors were silently ignored, so a failed image push (e.g. due to an expired token in the
+        machine's docker credential store, which is now bypassed by passing ECR credentials
+        explicitly) led to Batch jobs failing later with "image not found" instead of a clear
+        error at push time.

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -147,3 +147,12 @@ Development Changelog
         files inside the AWS and GCP containers. That argument was removed from the standard
         library in Python 3.9, so every Batch task crashed with a ``TypeError`` immediately after
         downloading its job file.
+
+    .. change::
+        :tags: aws, bugfix
+        :pullreq: 521
+
+        Raises the docker client timeout from 60 seconds to an hour -- starting the local
+        postprocessing container can exceed a minute when a large buildstock directory is
+        bind-mounted through Docker Desktop's file sharing on Windows -- and removes a leftover
+        ``bsb_post`` container from a previous interrupted run before starting a new one.

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -104,9 +104,6 @@ Development Changelog
         venv now lives at ``/buildstock-batch/.venv``, the AWS/GCP job commands reference its interpreter
         explicitly, and uv no longer installs a bare ``python3.11`` shim that would shadow a base image's
         own ``python3.11`` (which, for ComStock, has PySAM and other measure dependencies installed).
-        Also adds ``dask-scheduler``/``dask-worker`` compatibility shims, since dask_cloudprovider
-        launches Fargate postprocessing containers with those legacy commands, which modern
-        distributed no longer installs.
 
     .. change::
         :tags: aws, bugfix
@@ -122,10 +119,10 @@ Development Changelog
         :pullreq: 521
 
         Adds an optional ``aws.vpc`` configuration (``vpc_id``, ``subnet_ids``, and optionally
-        ``security_group_id``) to run AWS Batch and the Fargate dask cluster in an existing VPC
-        instead of creating a new one. This supports accounts where ``ec2:CreateVpc`` is denied
-        by policy. When set, buildstockbatch does not create, modify, or delete anything in the
-        VPC, including during ``--clean``.
+        ``security_group_id``) to run AWS Batch in an existing VPC instead of creating a new
+        one. This supports accounts where ``ec2:CreateVpc`` is denied by policy. When set,
+        buildstockbatch does not create, modify, or delete anything in the VPC, including
+        during ``--clean``.
 
     .. change::
         :tags: aws, bugfix
@@ -152,29 +149,19 @@ Development Changelog
         :tags: aws, bugfix
         :pullreq: 521
 
-        Raises the docker client timeout from 60 seconds to an hour -- starting the local
-        postprocessing container can exceed a minute when a large buildstock directory is
-        bind-mounted through Docker Desktop's file sharing on Windows -- and removes a leftover
-        ``bsb_post`` container from a previous interrupted run before starting a new one.
-
-    .. change::
-        :tags: aws, bugfix
-        :pullreq: 521
-
-        Several AWS postprocessing fixes: adds an optional ``aws.vpc.dask_subnet_ids`` setting so
-        the Fargate dask cluster can run in public subnets (its scheduler must be reachable from
-        the machine running postprocessing) while Batch compute stays in private subnets; skips
-        dask_cloudprovider's stale-resource sweep when using an existing VPC (it deletes security
-        groups by name, which only works in the default VPC); copies a precomputed sample file
-        into the postprocessing container, where the sampler re-validates it; and raises an error
-        when the postprocessing container exits nonzero instead of silently succeeding.
+        Raises the docker client timeout from 60 seconds to an hour, since some docker API
+        operations (e.g. uploading a large build context through Docker Desktop's file sharing
+        on Windows) can take longer than a minute.
 
     .. change::
         :tags: aws, feature
         :pullreq: 521
 
-        Adds ``aws.dask.use_fargate_cluster`` (default true). When false, postprocessing runs on
-        a local dask cluster inside the postprocessing container instead of launching an AWS
-        Fargate cluster. Useful for small runs and for machines that cannot reach the Fargate
-        dask scheduler (e.g. corporate networks that block the dask protocol on port 8786, which
-        manifests as "Cluster failed to start ... Stream is closed").
+        AWS postprocessing now runs as an AWS Batch job in the cloud (mirroring how it runs as
+        a Cloud Run job on GCP), reading from and writing to S3 directly. It no longer runs in
+        a docker container on the machine that submitted the batch, and no longer launches an
+        AWS Fargate dask cluster, whose scheduler had to be reachable from that machine on port
+        8786 -- something many institutional networks block. The size of the postprocessing job
+        is configurable with the new ``aws.postprocessing_environment`` section (``vcpus`` and
+        ``memory``), and the ``aws.dask`` configuration section is removed. The
+        dask-cloudprovider dependency is no longer needed.

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -107,3 +107,12 @@ Development Changelog
         Also adds ``dask-scheduler``/``dask-worker`` compatibility shims, since dask_cloudprovider
         launches Fargate postprocessing containers with those legacy commands, which modern
         distributed no longer installs.
+
+    .. change::
+        :tags: aws, bugfix
+        :pullreq: 521
+
+        Applies the ``aws.tags`` configuration to AWS resources that previously weren't tagged:
+        IAM roles, the Batch instance profile, the ECR repository, and the Batch security group.
+        Job definitions now set ``propagateTags`` so the tags also reach the ECS tasks launched
+        for each simulation job.

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -81,3 +81,29 @@ Development Changelog
         :pullreq: 517
 
         Adds ``include_annual_foo`` arguments to the Residential HPXML Workflow Generator.
+
+    .. change::
+        :tags: aws, feature
+        :pullreq: 521
+
+        Adds optional ``aws.base_dockerfile`` and ``aws.base_target`` configuration options. When set,
+        buildstockbatch builds the specified Dockerfile from the buildstock directory (e.g. ComStock's
+        ``build/Dockerfile``) and uses the resulting image as the base for the buildstockbatch Docker
+        image, in place of the stock ``nrel/openstudio`` image. This allows running projects like
+        ComStock, whose simulation environment includes additional python dependencies and custom gems,
+        on AWS without publishing their image to a registry.
+
+    .. change::
+        :tags: aws, gcp, bugfix
+        :pullreq: 521
+
+        Fixes the cloud Dockerfile so buildstockbatch is actually present in the built image. The
+        python venv was previously created in the image's working directory, ``/var/simdata/openstudio``,
+        which the ``nrel/openstudio`` base image declares as a ``VOLUME`` -- files written there during
+        the build are discarded, so ``python3 -m buildstockbatch...`` failed inside the container. The
+        venv now lives at ``/buildstock-batch/.venv``, the AWS/GCP job commands reference its interpreter
+        explicitly, and uv no longer installs a bare ``python3.11`` shim that would shadow a base image's
+        own ``python3.11`` (which, for ComStock, has PySAM and other measure dependencies installed).
+        Also adds ``dask-scheduler``/``dask-worker`` compatibility shims, since dask_cloudprovider
+        launches Fargate postprocessing containers with those legacy commands, which modern
+        distributed no longer installs.

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -165,3 +165,24 @@ Development Changelog
         is configurable with the new ``aws.postprocessing_environment`` section (``vcpus`` and
         ``memory``), and the ``aws.dask`` configuration section is removed. The
         dask-cloudprovider dependency is no longer needed.
+
+    .. change::
+        :tags: aws, gcp, bugfix
+        :pullreq: 521
+
+        The ``max_minutes_per_sim`` configuration option is now honored by the cloud (AWS/GCP)
+        simulation workers, matching the local and HPC behavior: a simulation exceeding the
+        limit is terminated and recorded as failed, and the worker moves on to its next
+        simulation. Previously a hung simulation would stall its whole Batch task
+        indefinitely. Also fixes the AWS Batch array size to match the actual number of
+        simulation batches instead of ``aws.batch_array_size`` (which could submit tasks
+        with no assigned work that then crashed and failed the whole array job).
+
+    .. change::
+        :tags: aws, feature
+        :pullreq: 521
+
+        Adds the ``--missingonly`` command line option for AWS (matching GCP), which reruns
+        only the simulation batches that are missing results from a previous run of the same
+        project, then runs postprocessing. Useful for recovering a run in which some tasks
+        failed, e.g. from repeated spot instance reclamation.

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -84,7 +84,7 @@ Development Changelog
 
     .. change::
         :tags: aws, feature
-        :pullreq: 521
+        :pullreq: 527
 
         Adds optional ``aws.base_dockerfile`` and ``aws.base_target`` configuration options. When set,
         buildstockbatch builds the specified Dockerfile from the buildstock directory (e.g. ComStock's
@@ -95,7 +95,7 @@ Development Changelog
 
     .. change::
         :tags: aws, gcp, bugfix
-        :pullreq: 521
+        :pullreq: 527
 
         Fixes the cloud Dockerfile so buildstockbatch is actually present in the built image. The
         python venv was previously created in the image's working directory, ``/var/simdata/openstudio``,
@@ -107,7 +107,7 @@ Development Changelog
 
     .. change::
         :tags: aws, bugfix
-        :pullreq: 521
+        :pullreq: 527
 
         Applies the ``aws.tags`` configuration to AWS resources that previously weren't tagged:
         IAM roles, the Batch instance profile, the ECR repository, and the Batch security group.
@@ -116,7 +116,7 @@ Development Changelog
 
     .. change::
         :tags: aws, feature
-        :pullreq: 521
+        :pullreq: 527
 
         Adds an optional ``aws.vpc`` configuration (``vpc_id``, ``subnet_ids``, and optionally
         ``security_group_id``) to run AWS Batch in an existing VPC instead of creating a new
@@ -126,7 +126,7 @@ Development Changelog
 
     .. change::
         :tags: aws, bugfix
-        :pullreq: 521
+        :pullreq: 527
 
         Fixes two AWS submission bugs: jobs were submitted immediately after the Batch job queue
         was created, failing with "JobQueue not in VALID state" when the queue was still being
@@ -138,7 +138,7 @@ Development Changelog
 
     .. change::
         :tags: aws, gcp, bugfix
-        :pullreq: 521
+        :pullreq: 527
 
         Removes the ``encoding`` argument from the ``json.load`` calls that read the per-task job
         files inside the AWS and GCP containers. That argument was removed from the standard
@@ -147,7 +147,7 @@ Development Changelog
 
     .. change::
         :tags: aws, bugfix
-        :pullreq: 521
+        :pullreq: 527
 
         Raises the docker client timeout from 60 seconds to an hour, since some docker API
         operations (e.g. uploading a large build context through Docker Desktop's file sharing
@@ -155,7 +155,7 @@ Development Changelog
 
     .. change::
         :tags: aws, feature
-        :pullreq: 521
+        :pullreq: 527
 
         AWS postprocessing now runs as an AWS Batch job in the cloud (mirroring how it runs as
         a Cloud Run job on GCP), reading from and writing to S3 directly. It no longer runs in
@@ -168,7 +168,7 @@ Development Changelog
 
     .. change::
         :tags: aws, gcp, bugfix
-        :pullreq: 521
+        :pullreq: 527
 
         The ``max_minutes_per_sim`` configuration option is now honored by the cloud (AWS/GCP)
         simulation workers, matching the local and HPC behavior: a simulation exceeding the
@@ -180,7 +180,7 @@ Development Changelog
 
     .. change::
         :tags: aws, feature
-        :pullreq: 521
+        :pullreq: 527
 
         Adds the ``--missingonly`` command line option for AWS (matching GCP), which reruns
         only the simulation batches that are missing results from a previous run of the same

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -156,3 +156,15 @@ Development Changelog
         postprocessing container can exceed a minute when a large buildstock directory is
         bind-mounted through Docker Desktop's file sharing on Windows -- and removes a leftover
         ``bsb_post`` container from a previous interrupted run before starting a new one.
+
+    .. change::
+        :tags: aws, bugfix
+        :pullreq: 521
+
+        Several AWS postprocessing fixes: adds an optional ``aws.vpc.dask_subnet_ids`` setting so
+        the Fargate dask cluster can run in public subnets (its scheduler must be reachable from
+        the machine running postprocessing) while Batch compute stays in private subnets; skips
+        dask_cloudprovider's stale-resource sweep when using an existing VPC (it deletes security
+        groups by name, which only works in the default VPC); copies a precomputed sample file
+        into the postprocessing container, where the sampler re-validates it; and raises an error
+        when the postprocessing container exits nonzero instead of silently succeeding.

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -168,3 +168,13 @@ Development Changelog
         groups by name, which only works in the default VPC); copies a precomputed sample file
         into the postprocessing container, where the sampler re-validates it; and raises an error
         when the postprocessing container exits nonzero instead of silently succeeding.
+
+    .. change::
+        :tags: aws, feature
+        :pullreq: 521
+
+        Adds ``aws.dask.use_fargate_cluster`` (default true). When false, postprocessing runs on
+        a local dask cluster inside the postprocessing container instead of launching an AWS
+        Fargate cluster. Useful for small runs and for machines that cannot reach the Fargate
+        dask scheduler (e.g. corporate networks that block the dask protocol on port 8786, which
+        manifests as "Cluster failed to start ... Stream is closed").

--- a/docs/changelog/changelog_dev.rst
+++ b/docs/changelog/changelog_dev.rst
@@ -138,3 +138,12 @@ Development Changelog
         machine's docker credential store, which is now bypassed by passing ECR credentials
         explicitly) led to Batch jobs failing later with "image not found" instead of a clear
         error at push time.
+
+    .. change::
+        :tags: aws, gcp, bugfix
+        :pullreq: 521
+
+        Removes the ``encoding`` argument from the ``json.load`` calls that read the per-task job
+        files inside the AWS and GCP containers. That argument was removed from the standard
+        library in Python 3.9, so every Batch task crashed with a ``TypeError`` immediately after
+        downloading its job file.

--- a/docs/project_defn.rst
+++ b/docs/project_defn.rst
@@ -244,6 +244,10 @@ on the `AWS Batch <https://aws.amazon.com/batch/>`_ service.
    subscription to receive further notification emails. This doesn't work right now.
 *  ``dask``: (required) Dask configuration for postprocessing
 
+   * ``use_fargate_cluster``: (optional) Default true. When false, postprocessing runs on a
+     local dask cluster inside the postprocessing container instead of an AWS Fargate cluster.
+     Use this for small runs, or when the Fargate dask scheduler isn't reachable from the
+     machine running postprocessing (e.g. corporate networks that block the dask protocol).
    * ``n_workers``: (required) Number of dask workers to use.
    * ``scheduler_cpu``: (optional) One of ``[1024, 2048, 4096, 8192, 16384]``.
      Default: 2048. CPU to allocate for the scheduler task. 1024 = 1 VCPU. See

--- a/docs/project_defn.rst
+++ b/docs/project_defn.rst
@@ -91,16 +91,16 @@ Information about baseline simulations are listed under the ``baseline`` key.
 - ``skip_sims``: Include this key to control whether the set of baseline simulations are run. The default (i.e., when
   this key is not included) is to run all the baseline simulations. No results csv table with baseline characteristics
   will be provided when the baseline simulations are skipped.
-- ``custom_gems``: true or false. **ONLY WORKS ON KESTREL AND LOCAL**
+- ``custom_gems``: true or false.
   When true, buildstockbatch will call the OpenStudio CLI commands with the
   ``bundle`` and ``bundle_path`` options. These options tell the CLI to load a
-  custom set of gems rather than those included in the OpenStudio CLI. For both
-  Kestrel and local Docker runs, these gems are first specified in the
-  ``buildstock\resources\Gemfile``. For Kestrel, when the apptainer image
-  is built, these gems are added to the image. For local Docker, when the
-  containers are started, the gems specified in the Gemfile are installed into a
-  Docker volume on the local computer. This volume is mounted by each container
-  as models are run, so each run uses the custom gems.
+  custom set of gems rather than those included in the OpenStudio CLI. These
+  gems are specified in the ``buildstock\resources\Gemfile``. For Kestrel, the
+  gems must already be included in the apptainer image. For local runs, the
+  gems are installed into ``buildstock\.custom_gems`` on the local computer.
+  For AWS/GCP, the gems are bundled into the Docker image when it is built,
+  unless ``base_dockerfile`` is set, in which case the base image is expected
+  to already contain them at ``/var/oscli``.
 
 OpenStudio Version
 ~~~~~~~~~~~~~~~~~~
@@ -207,6 +207,16 @@ on the `AWS Batch <https://aws.amazon.com/batch/>`_ service.
     *  ``prefix``: The s3 prefix at which the data will be stored.
 
 *  ``region``: (required) The AWS region in which the batch will be run and data stored. Probably "us-west-2" if you're at NREL.
+*  ``base_dockerfile``: (optional) Path, relative to ``buildstock_directory``, of a Dockerfile
+   to build and use as the base image for the buildstockbatch simulation image, in place of the
+   stock ``nrel/openstudio`` image. Use this when the project provides its own simulation
+   environment (e.g. ComStock's ``build/Dockerfile``, which adds python dependencies used by its
+   measures). The resulting image must contain OpenStudio matching ``os_version``, plus ``curl``
+   and ``ca-certificates``. When this is set along with ``baseline.custom_gems``, the base image
+   is expected to provide the custom gems and Gemfile at ``/var/oscli`` (as ComStock's does), and
+   buildstockbatch will not run its own ``bundle install``.
+*  ``base_target``: (optional) Name of the build stage to target in ``base_dockerfile``, if it
+   is a multi-stage Dockerfile (e.g. ``os-comstock``).
 *  ``use_spot``: (optional) true or false. Defaults to true if missing. This tells the project
    to use the `Spot Market <https://aws.amazon.com/ec2/spot/>`_ for data
    simulations, which typically yields about 60-70% cost savings.

--- a/docs/project_defn.rst
+++ b/docs/project_defn.rst
@@ -223,8 +223,11 @@ on the `AWS Batch <https://aws.amazon.com/batch/>`_ service.
    the Batch instances can reach ECR and S3.
 
     * ``vpc_id``: (required) The id of the existing VPC, e.g. ``vpc-0123456789abcdef0``.
-    * ``subnet_ids``: (required) List of subnet ids in that VPC to run Batch compute and Fargate
-      postprocessing tasks in.
+    * ``subnet_ids``: (required) List of subnet ids in that VPC to run Batch compute in.
+    * ``dask_subnet_ids``: (optional) List of subnet ids for the Fargate dask postprocessing
+      cluster. The dask scheduler must be reachable on port 8786 from the machine running
+      postprocessing, so these should generally be public (internet-gateway-routed) subnets.
+      Defaults to ``subnet_ids``.
     * ``security_group_id``: (optional) Security group id to use. Defaults to the VPC's default
       security group. Must allow outbound traffic.
 *  ``use_spot``: (optional) true or false. Defaults to true if missing. This tells the project

--- a/docs/project_defn.rst
+++ b/docs/project_defn.rst
@@ -242,7 +242,8 @@ on the `AWS Batch <https://aws.amazon.com/batch/>`_ service.
 
     * ``vcpus``: (optional) Number of CPUs needed. Default: 1. This probably doesn't need to be changed.
     * ``memory``: (optional) Amount of RAM memory needed for each simulation in MiB. default 1024. For large multifamily buildings
-      this works better if set to 2048.
+      this works better if set to 2048. Large commercial models (e.g. ComStock hospitals, the same models that
+      dominate the long tail of simulation runtimes) may also need more than the default.
 *  ``postprocessing_environment``: (optional) Specifies the computing requirements for the
    postprocessing job. Postprocessing runs as a separate AWS Batch job in the cloud, reading
    from and writing to S3 directly, so it needs no connection back to the machine that

--- a/docs/project_defn.rst
+++ b/docs/project_defn.rst
@@ -217,6 +217,16 @@ on the `AWS Batch <https://aws.amazon.com/batch/>`_ service.
    buildstockbatch will not run its own ``bundle install``.
 *  ``base_target``: (optional) Name of the build stage to target in ``base_dockerfile``, if it
    is a multi-stage Dockerfile (e.g. ``os-comstock``).
+*  ``vpc``: (optional) Use an existing VPC instead of creating one. Use this in accounts where
+   VPC creation is not permitted. Nothing in the VPC is created, modified, or deleted by
+   buildstockbatch. The subnets must have outbound internet access (e.g. via a NAT gateway) so
+   the Batch instances can reach ECR and S3.
+
+    * ``vpc_id``: (required) The id of the existing VPC, e.g. ``vpc-0123456789abcdef0``.
+    * ``subnet_ids``: (required) List of subnet ids in that VPC to run Batch compute and Fargate
+      postprocessing tasks in.
+    * ``security_group_id``: (optional) Security group id to use. Defaults to the VPC's default
+      security group. Must allow outbound traffic.
 *  ``use_spot``: (optional) true or false. Defaults to true if missing. This tells the project
    to use the `Spot Market <https://aws.amazon.com/ec2/spot/>`_ for data
    simulations, which typically yields about 60-70% cost savings.

--- a/docs/project_defn.rst
+++ b/docs/project_defn.rst
@@ -224,10 +224,6 @@ on the `AWS Batch <https://aws.amazon.com/batch/>`_ service.
 
     * ``vpc_id``: (required) The id of the existing VPC, e.g. ``vpc-0123456789abcdef0``.
     * ``subnet_ids``: (required) List of subnet ids in that VPC to run Batch compute in.
-    * ``dask_subnet_ids``: (optional) List of subnet ids for the Fargate dask postprocessing
-      cluster. The dask scheduler must be reachable on port 8786 from the machine running
-      postprocessing, so these should generally be public (internet-gateway-routed) subnets.
-      Defaults to ``subnet_ids``.
     * ``security_group_id``: (optional) Security group id to use. Defaults to the VPC's default
       security group. Must allow outbound traffic.
 *  ``use_spot``: (optional) true or false. Defaults to true if missing. This tells the project
@@ -242,32 +238,20 @@ on the `AWS Batch <https://aws.amazon.com/batch/>`_ service.
 *  ``notifications_email``: (required) Email to notify you of simulation completion.
    You'll receive an email at the beginning where you'll need to accept the
    subscription to receive further notification emails. This doesn't work right now.
-*  ``dask``: (required) Dask configuration for postprocessing
-
-   * ``use_fargate_cluster``: (optional) Default true. When false, postprocessing runs on a
-     local dask cluster inside the postprocessing container instead of an AWS Fargate cluster.
-     Use this for small runs, or when the Fargate dask scheduler isn't reachable from the
-     machine running postprocessing (e.g. corporate networks that block the dask protocol).
-   * ``n_workers``: (required) Number of dask workers to use.
-   * ``scheduler_cpu``: (optional) One of ``[1024, 2048, 4096, 8192, 16384]``.
-     Default: 2048. CPU to allocate for the scheduler task. 1024 = 1 VCPU. See
-     `Fargate Task CPU and memory`_ for allowable combinations of CPU and
-     memory.
-   * ``scheduler_memory``: (optional) Amount of memory to allocate to the
-     scheduler task. Default: 8192. See `Fargate Task CPU and memory`_ for
-     allowable combinations of CPU and memory.
-   * ``worker_cpu``: (optional) One of ``[1024, 2048, 4096, 8192, 16384]``.
-     Default: 2048. CPU to allocate for the worker tasks. 1024 = 1 VCPU. See
-     `Fargate Task CPU and memory`_ for allowable combinations of CPU and
-     memory.
-   * ``worker_memory``: (optional) Amount of memory to allocate to the worker
-     tasks. Default: 8192. See `Fargate Task CPU and memory`_ for allowable
-     combinations of CPU and memory.
 *  ``job_environment``: Specifies the computing requirements for each simulation.
 
     * ``vcpus``: (optional) Number of CPUs needed. Default: 1. This probably doesn't need to be changed.
     * ``memory``: (optional) Amount of RAM memory needed for each simulation in MiB. default 1024. For large multifamily buildings
       this works better if set to 2048.
+*  ``postprocessing_environment``: (optional) Specifies the computing requirements for the
+   postprocessing job. Postprocessing runs as a separate AWS Batch job in the cloud, reading
+   from and writing to S3 directly, so it needs no connection back to the machine that
+   submitted the batch (which may safely be interrupted while it runs).
+
+    * ``vcpus``: (optional) Number of CPUs for the postprocessing job. Also sets the number of
+      dask workers. Default: 4.
+    * ``memory``: (optional) Amount of RAM in MiB for the postprocessing job. Default: 30720.
+      Increase this for large runs with timeseries output.
 *  ``tags``: (optional) This is a list of key-value pairs to attach as tags to
    all the AWS objects created in the process of running the simulation. If you
    are at NREL, please fill out the following tags so we can track and allocate
@@ -275,7 +259,6 @@ on the `AWS Batch <https://aws.amazon.com/batch/>`_ service.
 
 
 .. _instance type: https://aws.amazon.com/ec2/instance-types/
-.. _Fargate Task CPU and memory: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html#fargate-tasks-size
 
 
 .. _gcp-config:

--- a/docs/run_sims.rst
+++ b/docs/run_sims.rst
@@ -107,8 +107,6 @@ file, something like this:
       region: us-west-2
       use_spot: true
       batch_array_size: 10000
-      dask:
-        n_workers: 8
       notifications_email: your_email@somewhere.com  # doesn't work right now
 
 See :ref:`aws-config` for details.

--- a/docs/run_sims.rst
+++ b/docs/run_sims.rst
@@ -111,6 +111,18 @@ file, something like this:
 
 See :ref:`aws-config` for details.
 
+Retry failed tasks
+..................
+
+Occasionally, especially when using spot instances, tasks will fail for transient reasons, like
+the instance being reclaimed. While reclaimed tasks are automatically retried, if they continue
+to fail, the entire job will fail and postprocessing will not run.
+
+If this happens, you can rerun the same job with the ``--missingonly`` flag. This will rerun only
+the tasks that didn't produce output files, then run postprocessing. Note: This flag assumes that
+your project config file has not changed since the previous run. If it has changed, the behavior
+is undefined.
+
 Cleaning up after yourself
 ..........................
 

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,7 @@ gcp_requires = [
     "tqdm",
 ]
 
-aws_requires = [
-    "dask-cloudprovider[aws]>=2024.9.0",
-]
+aws_requires = []
 
 
 setuptools.setup(


### PR DESCRIPTION
## Summary

This PR makes it possible to run ComStock on AWS with buildstockbatch, and in the process revives and hardens the AWS path generally. Everything here was verified end-to-end against a live AWS account with an 8-building ComStock test project: image build -> ECR push -> Batch simulations (8/8 Success) -> cloud postprocessing including timeseries parquet -> `--clean` teardown, plus a live `--missingonly` recovery test.

### Custom base image support (`aws.base_dockerfile` / `aws.base_target`)

Projects like ComStock provide their own simulation environment (extra python dependencies such as PySAM for the utility bills measure, `ghedesigner`, and custom gems). The new optional `aws.base_dockerfile` config builds a Dockerfile from the buildstock directory locally and uses it as the base for the buildstockbatch image, instead of the stock `nrel/openstudio` image -- no obligation for the project to publish an image to a registry. `aws.base_target` selects a stage in a multi-stage Dockerfile. When combined with `baseline.custom_gems`, the gems are taken from the base image (at `/var/oscli`) rather than re-bundled.

### Postprocessing runs in the cloud

AWS postprocessing now runs as an AWS Batch job (mirroring GCP's Cloud Run job), reading and writing S3 directly with a dask LocalCluster sized by the new `aws.postprocessing_environment` config. The submitting machine just polls status and tails CloudWatch logs. This removes the previous requirement that a Fargate dask scheduler be reachable from the submitting machine on port 8786 (blocked by many institutional networks). The `aws.dask` config, the Fargate cluster, the local `bsb_post` container, and the dask-cloudprovider dependency are all removed.

### Existing VPC support (`aws.vpc`)

For accounts where `ec2:CreateVpc` is denied by policy, `aws.vpc` (`vpc_id`, `subnet_ids`, optional `security_group_id`) runs Batch in an existing VPC. buildstockbatch never creates, modifies, or deletes anything in that VPC, including during `--clean` (verified live: default security group and subnets untouched after teardown).

### Reliability & resilience

Informed by runtime data from a production ComStock run (103k sims: median 2.8 min, p99 41 min, max 3.1 h -- hospitals dominate the tail):

- `max_minutes_per_sim` is now honored by the cloud (AWS/GCP) workers, matching local/HPC: a runaway simulation is terminated and recorded as failed instead of stalling its Batch task indefinitely.
- New `--missingonly` flag for AWS (same as GCP): rerun only the task batches missing results, then postprocess -- a cheap recovery path after spot reclamation failures. Verified live.
- Batch array size now matches the actual number of simulation batches; tasks with no assigned work exit gracefully.
- Job submission waits for the job queue to reach VALID (was a race that failed submissions).
- docker push errors are surfaced instead of silently ignored (a failed push previously manifested later as "image not found" in Batch), and ECR credentials are passed explicitly to bypass stale tokens in the local docker credential store.
- `aws.tags` now applied to IAM roles, the instance profile, the ECR repository, and the Batch security group; job definitions set `propagateTags` so tags reach the ECS tasks.

### Latent AWS/GCP bugs fixed (these prevented *any* AWS run from working)

- The python venv in the Docker image was created under `/var/simdata/openstudio`, which the base image declares as a `VOLUME` -- everything written there during the build was discarded, so buildstockbatch wasn't actually in the image. The venv now lives at `/buildstock-batch/.venv` and job commands reference its interpreter explicitly.
- `json.load(..., encoding="utf-8")` crashed every Batch task (that argument was removed in Python 3.9).
- uv's `python3.11` shim no longer shadows a base image's own `python3.11` (which for ComStock carries measure dependencies).

## Testing

- Unit tests: `test_docker_base.py` 14/14 passing, including new tests for the two-phase image build, base-dockerfile validation, and the per-sim timeout path.
- Live AWS validation (account with org VPC + CreateVpc deny): full pipeline, `--postprocessonly`, `--missingonly` recovery, and `--clean` all verified. All resources tagged and confirmed cleaned up afterward.
- Companion ComStock changes (`.dockerignore`, updated integration sample and yml) are on the `asparke2/bsb_aws_integration_fixes` branch of NREL/ComStock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
